### PR TITLE
Output of line cubes (fits files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ FLiTs*
 /.cproject
 /.project
 /.settings/
+Makefile.local
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.exclude": {
+        "*.mod": true,
+        "*.o": true
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.exclude": {
-        "*.mod": true,
-        "*.o": true
-    }
-}

--- a/Init.f
+++ b/Init.f
@@ -97,6 +97,8 @@ c				all arguments are read
 			read(value,*) accuracy
 		case("imagecube","imcube")
 			read(value,*) imagecube
+		case("imagecube_npix","imcube_npix")
+			read(value,*) npix
 		case("idum","seed")
 			read(value,*) idum
 		case default
@@ -174,7 +176,9 @@ c===============================================================================
 	
 	doblend=.true.
 	
+	! imagecube false by default
 	imagecube=.false.
+	npix=0 ! FIXME: not check yet for the case of imagecube=true
 	
 	return
 	end

--- a/Modules.f
+++ b/Modules.f
@@ -54,7 +54,7 @@ c the image grid
 	real*8 vmax
 
 c the image cube
-	real*8,allocatable :: x_im(:,:,:),y_im(:,:,:)
+	real*8,allocatable :: x_im(:,:,:),y_im(:,:,:),im_coord(:)
 	real*8,allocatable :: imcube(:,:,:)
 	integer nint,npix,nvim
 	logical imagecube
@@ -138,7 +138,9 @@ c surface area of this path in the image and its coordinates
 
 		real*8,allocatable :: v(:),d(:),v1(:),v2(:)
 		integer,allocatable :: i(:),j(:)
-
+		integer*2,allocatable :: im_ixy(:,:) ! first axis =2 (x,y), second axis can theoretically go to npix*2 (all pixels), 
+										   ! but is likely much smaller FIXME don't know to estimate that, take npix for now
+		integer*2 :: im_npix    ! nubmer of pixels associated to that path
 		real*8,allocatable :: flux_cont(:) !continuum contribution at each wavelength
 		real*8,allocatable :: cont_contr(:) !continuum contribution at each path element
 		real*8,allocatable :: exptau_dust(:) !dust optical depth at each path element

--- a/Modules.f
+++ b/Modules.f
@@ -57,6 +57,7 @@ c the image cube
 	real*8,allocatable :: x_im(:,:,:),y_im(:,:,:),im_coord(:)
 	real*8,allocatable :: imcube(:,:,:)
 	integer nint,npix,nvim
+	integer*4,allocatable :: imcube_hit(:,:,:)
 	logical imagecube
 
 c store all the blackbodies

--- a/RaytraceLines.f
+++ b/RaytraceLines.f
@@ -68,6 +68,7 @@
 
 	if(imagecube) then
 		allocate(imcube(npix,npix,nvmin:nvmax))
+		allocate(imcube_hit(npix,npix,nvmin:nvmax))
 		allocate(im_coord(npix))
 		delpix=2.d0*Rout*AU/real(npix)	
 		! create the center coordinates for the pixels		
@@ -75,6 +76,7 @@
 			im_coord(i)=delpix/2d0+delpix*(i-1)-Rout*AU
 		enddo	
 		!write(*,*) im_coord/AU
+		
 	endif
 
 	lam=lmin
@@ -126,6 +128,7 @@
 	do iblends=1,nblends
 		if(imagecube) then
 			imcube=0d0 ! FIXME: in the end I want only one cube, not for each blend, I think that shoulbe be moved outside of the blends loop (like flux)
+			imcube_hit=0
 		endif
 		flux=0d0
 		
@@ -247,7 +250,7 @@
 								flux0=flux_c
 							endif
 							flux4(iv)=flux4(iv)+flux0*PP%A/2d0
-							if(imagecube) call AddImage(iv,i,j,flux0*PP%A/2d0,PP,vmult,"call nb 1")
+							if(imagecube) call AddImage(iv,flux0*PP%A/2d0,PP,vmult,"call nb 1")
 							vmult=1
 							doit_ib(1:nb)=doit_ib0(1:nb)
 							gas=.false.
@@ -267,7 +270,7 @@
 							flux4(iv)=flux4(iv)+flux0*PP%A/2d0
 							! FIXME: I think here  times vmult is required, but then it should also be in the line above ? or maybe not
 							! or maybe in that case vmult also needs to be ignored for the imagecube
-							if(imagecube) call AddImage(iv,i,j,flux0*PP%A/2d0,PP,vmult,"call nb 2")
+							if(imagecube) call AddImage(iv,flux0*PP%A/2d0,PP,vmult,"call nb 2")
 
 						else if(((real(iv)+0.5d0)*vresolution.gt.PP%vmax(LL%imol).and.
      &                           (real(iv)-0.5d0)*vresolution.gt.PP%vmax(LL%imol))
@@ -280,7 +283,7 @@
 								! FIXME: callerstring is only for debugging, remove it 
 								write(callerstr,"(A,' ' ,i5,' ',i2)") "call nb else if", iv,vmult	
 								if(imagecube) then
-									call AddImage(iv*vmult,i,j,flux0*PP%A/2d0,PP,vmult,callerstr)
+									call AddImage(iv*vmult,flux0*PP%A/2d0,PP,vmult,callerstr)
 								endif
 							enddo							
 						else
@@ -290,7 +293,7 @@
 								flux4(iv*vmult)=flux4(iv*vmult)+flux0*PP%A/2d0								
 								write(callerstr,"(A,' ' ,i5,' ',i2)") "call nb else", iv,vmult																
 								if(imagecube) then 
-									call AddImage(iv*vmult,i,j,flux0*PP%A/2d0,PP,vmult,callerstr)
+									call AddImage(iv*vmult,flux0*PP%A/2d0,PP,vmult,callerstr)
 								endif
 							enddo							
 						endif
@@ -301,7 +304,7 @@
 				flux4(Bl%nvmin:Bl%nvmax)=flux4(Bl%nvmin:Bl%nvmax)+flux0*PP%A
 				if(imagecube) then
 					do iv=Bl%nvmin,Bl%nvmax
-						call AddImage(iv,i,j,flux0*PP%A,PP,1,"call not doit")
+						call AddImage(iv,flux0*PP%A,PP,1,"call not doit")
 					enddo
 				endif
 			endif
@@ -322,15 +325,12 @@
 		do iv=Bl%nvmin,Bl%nvmax
 			if(nb.gt.1) then  ! FIXME: this if seems to be unnecessary
 				call Trace2StarLines(PP,flux0,iv,imol_blend,v_blend,nb)
-				flux(iv)=flux(iv)+flux0*PP%A				
+				flux(iv)=flux(iv)+flux0*PP%A								
 			else
 				call Trace2StarLines(PP,flux0,iv,imol_blend,v_blend,nb)
 				flux(iv)=flux(iv)+flux0*PP%A
-			endif
-			! FIXME: workaround assume that the star is at the center of the grid
-			PP%im_ixy(:,1)=int(npix/2)+1
-			PP%im_npix=1
-			if(imagecube) call AddImage(iv,0,0,flux0*PP%A,PP,1,"trace star")
+			endif			
+			if(imagecube) call AddImage(iv,flux0*PP%A,PP,1,"trace star")
 		enddo
 		flux2=flux2+flux0*PP%A
 
@@ -426,10 +426,18 @@
 			! currently this is per blend 
 			!call writefitsfile(imcubename,imcube*1e23/(distance*parsec)**2,nvmax-nvmin+1,npix)
 			!lam_velo=lam*sqrt((1d0+real(Bl%nvmin)*vresolution/clight)/(1d0-real(Bl%nvmin)*vresolution/clight))
-			call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2,nvmax-iv+1,npix,Bl%lam,lam_velo_imcube)
+
+			! to avoid nan, assumes that the pixels the should be hit are really hit
+			WHERE(imcube_hit.lt.1) imcube_hit=1
 			
-			!imcubename="imcube_hit" // trim(int2string(iblends,'(i0.10)')) // ".fits.gz"
-			!call writefitsfile(imcubename,imcube_hit,1,npix)
+			call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2,nvmax-iv+1,npix,Bl%lam,lam_velo_imcube,.false.)
+			
+			imcubename="imcube_wl" // trim(int2string(iblends,'(i0.10)')) // ".fits.gz"
+			call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2,nvmax-iv+1,npix,Bl%lam,lam_velo_imcube,.true.)
+			!call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2/imcube_hit(:,:,iv:nvmax),nvmax-iv+1,npix,Bl%lam,lam_velo_imcube)
+
+			imcubename="imcube_hit" // trim(int2string(iblends,'(i0.10)')) // ".fits.gz"
+			!call writefitsfile(imcubename,imcube_hit,nvmax-iv+1,npix,npix,Bl%lam,lam_velo_imcube)
 		endif		
 
 
@@ -856,7 +864,7 @@ c Using the source function for now.
 	implicit none
 	integer, intent(in) :: igrid,npath
 	real*8 :: px(npath),py(npath),dist(npath),im_x,im_y
-	real*8 :: maxx,maxy,maxr,maxrxp,maxrxm
+	real*8 :: maxx,maxy,maxr,maxrxp,maxrxm,pixA
 	type(Path),pointer :: p0
 
 	integer :: i,j,ipath,iminpath,maxnpixpath
@@ -867,6 +875,10 @@ c Using the source function for now.
 
 
 	write(*,*) "Mapping pixels to path igrid,npath",igrid,npath
+
+	! area of one pixel cm^2
+	pixA=(im_coord(2)-im_coord(1))**2
+
 
     
 	! the paths do not sample the whole image (just the disk)
@@ -930,9 +942,32 @@ c Using the source function for now.
 		p0%im_ixy(2,1)=minloc(abs(im_coord-p0%y),dim=1)
 	enddo 
 
+
+	! special treatment for the star
+	! assume here it is always just one pixel for the moment
+	! and only needs to be done once 
+	if (.not.allocated(path2star%im_ixy)) then 
+		allocate(path2star%im_ixy(2,1))
+
+		path2star%im_npix=1
+		path2star%im_ixy(1,1)=minloc(abs(im_coord-path2star%x),dim=1) 
+		path2star%im_ixy(2,1)=minloc(abs(im_coord-path2star%y),dim=1)
+		write(*,*) path2star%x,path2star%y,path2star%im_ixy(:,1)
+	endif
+
+	! some log output and set the correction factor
+
+	p0 => path2star
+	write(99,*) p0%x/AU,p0%y/AU,p0%A/AU/AU,p0%im_ixy(:,1),p0%im_npix,p0%im_npix*pixA/AU/AU
+
+	do ipath=1,npath
+		p0 => P(igrid,ipath)
+		write(99,*) p0%x/AU,p0%y/AU,p0%A/AU/AU,p0%im_ixy(:,1),p0%im_npix,p0%im_npix*pixA/AU/AU
+	enddo		
+
 	end subroutine map_pixels_to_path
 	
-	subroutine AddImage(iv,i,j,flux0,p0,vmult,caller) ! FIXME: don't need i, j anymore 
+	subroutine AddImage(iv,flux0,p0,vmult,caller) ! FIXME: don't need i, j anymore 
 	use GlobalSetup
 	use Constants
 	IMPLICIT NONE
@@ -941,11 +976,13 @@ c Using the source function for now.
 	integer, intent(in) :: vmult
 	type(Path), intent(in) :: p0
 	character(len=*), intent(in) :: caller	! just for logging, can be removed
-	integer i,j,iint,ix,iy,iym,ipix
-	real*8 :: delpix,fluxperpix
+	integer ix,iy,iym,ipix
+	real*8 :: delpix,fluxperpix,pixA
  
+	pixA=(im_coord(2)-im_coord(1))**2
 	! simply distribute the flux for the path over all pixels equally
 	fluxperpix=flux0/p0%im_npix
+	!fluxperpix=(flux0/p0%A)*pixA
 
 	do ipix=1,p0%im_npix
 
@@ -964,6 +1001,7 @@ c Using the source function for now.
 		! endif	
 		
 		imcube(iy,ix,iv)=imcube(iy,ix,iv)+fluxperpix ! P%y (Vertical) seems to be along the major axis - make it x
+		imcube_hit(iy,ix,iv)=imcube_hit(iy,ix,iv)+1
 	enddo
 	return
 	end

--- a/SetupPaths.f
+++ b/SetupPaths.f
@@ -221,7 +221,13 @@ c increase the resolution in velocity by this factor
 			imx=rr*cos(ph)*sin(tt)
 			imy=rr*sin(ph)*sin(tt)
 			imz=rr*cos(tt)
-			call rotate(imx,imy,imz,0d0,1d0,0d0,-inc*pi/180d0)
+			! CHR: my guess is that this rotate is done to optimiye the path grid 
+			! however, because of this rotate the outer edge of the disk is not sampled on 
+			! the far side of the disk. To be backward compatible still do the rotation if 
+			! imagecube is not used
+			if (.not.imagecube) then 
+				call rotate(imx,imy,imz,0d0,1d0,0d0,-inc*pi/180d0)
+			endif
 			xy(1,j)=imx
 			xy(2,j)=imy
 		enddo

--- a/writeFITS.f
+++ b/writeFITS.f
@@ -1,14 +1,17 @@
 	subroutine writefitsfile(filename,im,nlam,n)
-	use GlobalSetup, only: distance
-	use Constants, only: parsec
+	use GlobalSetup, only : Rout,distance,lmin,vresolution
+	use Constants, only : pi,clight,parsec,AU
 	IMPLICIT NONE
 	character*500 filename
-	integer n,nlam
+	integer,intent(in) :: nlam,n
+	real centerpix
 	real*8 im(n,n,nlam)
+	real*8 degree,delpix,spixdegree
 
-      integer status,unit,blocksize,bitpix,naxis,naxes(3)
-      integer i,j,group,fpixel,nelements
-      logical simple,extend,truefalse
+	integer status,unit,blocksize,bitpix,naxis,naxes(3)
+	integer i,j,group,fpixel,nelements
+	logical simple,extend,truefalse
+	real refFrqHz,delHz
 
 	inquire(file=filename,exist=truefalse)
 	if(truefalse) then
@@ -17,16 +20,17 @@
 		close(unit=90,status='delete')
 	endif
 
-      status=0
-C     Get an unused Logical Unit Number to use to create the FITS file
-      call ftgiou(unit,status)
-C     create the new empty FITS file
-      blocksize=1
-      call ftinit(unit,filename,blocksize,status)
+	status=0
+C   Get an unused Logical Unit Number to use to create the FITS file
+	call ftgiou(unit,status)
+C   create the new empty FITS file
+	blocksize=1
+	call ftinit(unit,filename,blocksize,status)
 
 C     initialize parameters about the FITS image (IMDIM x IMDIM 64-bit reals)
-      simple=.true.
-      bitpix=-64
+	simple=.true.
+	!bitpix=-64
+	bitpix=-32 ! single precision should be enough
 	naxes(1)=n
 	naxes(2)=n
 	if(nlam.gt.1) then
@@ -36,16 +40,67 @@ C     initialize parameters about the FITS image (IMDIM x IMDIM 64-bit reals)
 		naxis=2
 		naxes(3)=1
 	endif
-      extend=.true.
+	extend=.true.
 
 C     write the required header keywords
-      call ftphpr(unit,simple,bitpix,naxis,naxes,0,1,extend,status)
+	call ftphpr(unit,simple,bitpix,naxis,naxes,0,1,extend,status)
+
+	degree = pi/180.0           ! one degree in rad	
+
+	!----- constant size of all pixels in [sr] -----
+	! dist is from Parameter.in (is already converted to cm)
+	delpix=2.d0*Rout*AU/real(n)	! this is in cm
+	spixdegree  = delpix/(distance*parsec)/degree
+
+
+
+	! put some coordinate system 
+	centerpix=n/2+1.0 ! FIXME: requires odd number of pixesl
+	call ftpkys(unit,'ctype1','RA---SIN','',status)
+	call ftpkys(unit,'cunit1','deg     ','',status)
+	call ftpkyd(unit,'crval1',68.0,12,'dummy value',status)
+	call ftpkyd(unit,'cdelt1',spixdegree,12,'',status)
+	call ftpkyd(unit,'crota1',0.0,12,'',status)
+	call ftpkyd(unit,'crpix1',centerpix,12,'center pixel',status)
+
+	call ftpkys(unit,'ctype2','DEC--SIN','',status)
+	call ftpkys(unit,'cunit2','deg     ','',status)
+	call ftpkyd(unit,'crval2',24.0,12,'dummy value',status)
+	call ftpkyd(unit,'cdelt2',spixdegree,12,'',status)
+	call ftpkyd(unit,'crota2',0.0,12,'',status)
+	call ftpkyd(unit,'crpix2',centerpix,12,'center pixel',status)
+	call ftpkys(unit,'RADESYS','ICRS','',status)
+
+	! put in some grid for the velocity 
+	! reference is lmin
+
+	! the the first point (which should be lmin as the reference
+	refFrqHz=clight/(lmin/1.e4)
+	delHz=-refFrqHz*vresolution/clight
+
+    ! Frequency/Spectral coordinate
+    ! the first channel (velo) point is the reference
+	call ftpkys(unit,'CTYPE3','FREQ','[Hz]',status)
+	call ftpkys(unit,'cunit3','Hz      ','',status)
+	call ftpkyd(unit,'crval3',refFrqHz,12,'Reference FREQ',status)
+	call ftpkyd(unit,'CDELT3',delHz,12,'d_Hz (channel width)',status)
+	call ftpkyd(unit,'crpix3',1.0,12,'Reference channel',status)
+	! this is for velocity spectral units.
+	call ftpkys(unit,'SPECSYS','LSRK','Spectral reference frame',status)
+	call ftpkyj(unit,'VELREF',257,'Radio velocity in CASA',status)
+	call ftpkys(unit,'timesys','UTC     ','',status)
+	call ftpkys(unit,'cellscal','CONSTANT','',status)
+	call ftpkys(unit,'origin','FLiTs/ProDiMo model','',status)
+	! FIXME: does not make so much sense here if we have not a single line spectrum 
+	! but for now focus on a single line spectrum 
+	call ftpkyd(unit,'RESTFREQ',refFrqHz,12,'',status) ! this means first spectral axis point would give v=0
+
 
 C     write the array to the FITS file
       group=1
       fpixel=1
       nelements=naxes(1)*naxes(2)*naxes(3)
-      call ftpprd(unit,group,fpixel,nelements,im*1e23/(distance*parsec)**2,status)
+      call ftpprd(unit,group,fpixel,nelements,im,status)
 
 C     close the file and free the unit number
       call ftclos(unit, status)

--- a/writeFITS.f
+++ b/writeFITS.f
@@ -1,4 +1,6 @@
 	subroutine writefitsfile(filename,im,nlam,n)
+	use GlobalSetup, only: distance
+	use Constants, only: parsec
 	IMPLICIT NONE
 	character*500 filename
 	integer n,nlam
@@ -43,7 +45,7 @@ C     write the array to the FITS file
       group=1
       fpixel=1
       nelements=naxes(1)*naxes(2)*naxes(3)
-      call ftpprd(unit,group,fpixel,nelements,im,status)
+      call ftpprd(unit,group,fpixel,nelements,im*1e23/(distance*parsec)**2,status)
 
 C     close the file and free the unit number
       call ftclos(unit, status)


### PR DESCRIPTION
Produce a fits line cube for the considered wavelength range and considered molecules (all in one). 

- fix what is already there and check it with a linecube produced for ProDiMo (single line). 
- some input parameters might be missing (e.g. number of spatial pixels for the output ... maybe more)
- proper "conversion" of Jy/area (from spectrum calculation) to Jy/pixel might be necessary
- line cube might be huge, and needs large fits file support (e.g. check what is required to produce something for JWST) 
- apply a coordinate system to the cube (RA, Dex, e.g. like in ProDiMo, maybe make that optional)
- spectral axis might need to be flexible to e.g. produce something for CASA (velocity) and or JWST (micron) (optional as can also be done outside)
- units should be Jansky per pixel (e.g. okay for JWST and CASA/ALMA) 