### PR TITLE
Custom output filenames + formatting bugfix

### DIFF
--- a/Init.f
+++ b/Init.f
@@ -71,6 +71,10 @@ c				all arguments are read
 			stop
 		case("flitsfile")
 			FLiTsfile=value
+		case("outputfile")
+			outputFile=value
+		case("outputlinefluxfile")
+			output_lineFluxFile=value
 		case("lte")
 			read(value,*) LTE
 		case("blend")
@@ -157,6 +161,8 @@ c===============================================================================
 	Mstar=1d0
 	Rstar=1d0
 	FLiTsfile='ProDiMoForFLiTs.fits.gz'
+	outputFile='specFLiTs.out'
+	output_lineFluxFile='lineFlux_FLiTs.out'
 	lmin=5
 	lmax=50
 	inc=30d0

--- a/Modules.f
+++ b/Modules.f
@@ -37,7 +37,7 @@ c       external int2string,dbl2string
 
 c input files
 	character*500 linefile(100)
-	character*500 FLiTsfile
+	character*500 FLiTsfile, outputFile, output_lineFluxFile
 c type of structure. 1=MCMax(LTE,homogeneous abundance), 2=ProDiMo
 	integer structtype
 

--- a/RaytraceLines.f
+++ b/RaytraceLines.f
@@ -48,8 +48,8 @@
 		enddo
 	enddo
 
-	open(unit=20,file='specFLiTs.out',RECL=1500)
-	open(unit=21,file='lineFlux_FLiTs.out',RECL=1500)
+	open(unit=20,file=outputFile,RECL=1500)
+	open(unit=21,file=output_lineFluxFile,RECL=1500)
 	write(21,'("# lam[mu]   Fline[W/m^2]    lmin[mu]    lmax[mu]    comment")')
 
 	nv=int(vmax*1.1/vresolution)+1
@@ -150,7 +150,7 @@
 					enddo
 					enddo
 					flux0=flux0+path2star%flux_cont(k)*path2star%A
-					write(20,*) lam_cont(k),flux0*1e23/(distance*parsec)**2
+					write(20,"(F15.8, 1pE16.8)") lam_cont(k),flux0*1e23/(distance*parsec)**2
 				endif
 			enddo
 			ilam1=ilam
@@ -356,7 +356,7 @@
 		do iv=Bl%nvmin,Bl%nvmax
 			lam_velo=lam*sqrt((1d0+real(iv)*vresolution/clight)/(1d0-real(iv)*vresolution/clight))
 			if(lam_velo.gt.lmin_next) then
-				write(20,*) lam_velo,
+				write(20,"(F15.8, 1pE16.8, 1pE16.8, 1pE16.8, 3X, A)") lam_velo,
      &					flux(iv)*1e23/(distance*parsec)**2,
      &					real(iv)*vresolution/1d5,
      &					flux_cont(iv)*1e23/(distance*parsec)**2,
@@ -396,7 +396,7 @@ c		call tellertje_time(iblends,nblends,iblends,nblends,starttime)
 				flux0=flux0+PP%flux_cont(ilam)*PP%A
 			enddo
 			flux0=flux0+path2star%flux_cont(ilam)*path2star%A
-			write(20,*) lam_cont(ilam),flux0*1e23/(distance*parsec)**2
+			write(20,"(F15.8, 1pE16.8)") lam_cont(ilam),flux0*1e23/(distance*parsec)**2
 		endif
 		ilam=ilam+1
 	enddo


### PR DESCRIPTION
FLiTs produces two output files 'specFLiTs.out' and 'lineFlux_FLiTs.out'. I have made changes to accept custom user fed file names, which default to 'specFLiTs.out' and 'lineFlux_FLiTs.out' when not provided.
There were two places where the format for writing the output was not robustly defined, which led to ** characters in some cases. This is also fixed in this commit.