### PR TITLE
Creating line cubes (images)

### DIFF
--- a/ComputeLTE.f90
+++ b/ComputeLTE.f90
@@ -2,36 +2,39 @@ subroutine ComputeLTE()
   use GlobalSetup
   use Constants
   use InOut
-  implicit none  
-  integer :: i, j, k, imol
+  implicit none
+  integer :: i, j, k, imol, nLTE
   real(kind=8) :: UT, T
 
+  nLTE = 0
   do imol = 1, nmol
     if (Mol(imol)%LTE) then
       call output("Computing LTE level populations for "//trim(Mol(imol)%name))
+      nLTE = nLTE + 1
     end if
   end do
 
-  do i = 0, nR
-    call tellertje(i + 1, nR + 1)
-    do j = 1, nTheta
-      T = C(i, j)%Tgas
-      if (T .lt. 3d0) T = 3d0
-      do imol = 1, nmol
-        if (Mol(imol)%LTE) then
-          UT = 0d0
-          do k = 1, Mol(imol)%nlevels
-            UT = UT + Mol(imol)%g(k)*exp(-Mol(imol)%E(k)/T)
-          end do
+  if (nLTE > 0) then
+    do i = 0, nR
+      call tellertje(i + 1, nR + 1)
+      do j = 1, nTheta
+        T = C(i, j)%Tgas
+        if (T .lt. 3d0) T = 3d0
+        do imol = 1, nmol
+          if (Mol(imol)%LTE) then
+            UT = 0d0
+            do k = 1, Mol(imol)%nlevels
+              UT = UT + Mol(imol)%g(k)*exp(-Mol(imol)%E(k)/T)
+            end do
 
-          do k = 1, Mol(imol)%nlevels
-            C(i, j)%npop(imol)%N(k) = Mol(imol)%g(k)*exp(-Mol(imol)%E(k)/T)/UT
-          end do
-        end if
+            do k = 1, Mol(imol)%nlevels
+              C(i, j)%npop(imol)%N(k) = Mol(imol)%g(k)*exp(-Mol(imol)%E(k)/T)/UT
+            end do
+          end if
+        end do
       end do
     end do
-  end do
-
+  end if
   return
 end
 

--- a/Init.f90
+++ b/Init.f90
@@ -111,6 +111,8 @@ subroutine Initialize()
     read (value, *) ngrids
   case ("regular_grid")
     read (value, *) regular_grid
+  case ("correct_continuum")
+    read (value, *) correct_continuum
   case default
     call output("Unknown keyword: "//trim(key))
     stop
@@ -196,6 +198,7 @@ subroutine SetDefaults()
   regular_grid = .false.
   npix=0 ! FIXME: no check yet for the case of imagecube=true
   ngrids = 5
+  correct_continuum = .true.
   return
 end subroutine SetDefaults
 

--- a/Init.f90
+++ b/Init.f90
@@ -120,6 +120,11 @@ subroutine Initialize()
 30 continue
   close (unit=20)
 
+  if (imagecube .and. (npix .eq. 0 .or. mod(npix, 2) == 0)) then
+    call output("Error: if imagecube is true, npix must be set to a positive and odd integer value")
+    stop
+  end if
+
   vres_mult = vresolution/vres_profile
 
   if (abs(inc) .lt. 1d0) then

--- a/Init.f90
+++ b/Init.f90
@@ -107,6 +107,8 @@ subroutine Initialize()
     read (value, *) idum
   case ("ngrids")  ! number of grids to use for the line RT, Default is 5
     read (value, *) ngrids
+  case ("regular_grid")
+    read (value, *) regular_grid
   case default
     call output("Unknown keyword: "//trim(key))
     stop
@@ -123,6 +125,11 @@ subroutine Initialize()
   if (abs(inc) .lt. 1d0) then
     call output("Increasing inclination to 1 degrees")
     inc = 1
+  end if
+
+  if (regular_grid) then 
+    call output("Using a regular grid and set ngrids=1")
+    ngrids = 1
   end if
 
   call output("==================================================================")
@@ -178,6 +185,7 @@ subroutine SetDefaults()
   cylindrical = .true.
   doblend = .true.
   imagecube = .false.
+  regular_grid = .false.
   npix=0 ! FIXME: no check yet for the case of imagecube=true
   ngrids = 5
   return

--- a/Init.f90
+++ b/Init.f90
@@ -101,6 +101,8 @@ subroutine Initialize()
     read (value, *) accuracy
   case ("imagecube", "imcube")
     read (value, *) imagecube
+  case("imagecube_npix","imcube_npix")
+    read(value,*) npix
   case ("idum", "seed")
     read (value, *) idum
   case ("ngrids")  ! number of grids to use for the line RT, Default is 5
@@ -176,6 +178,7 @@ subroutine SetDefaults()
   cylindrical = .true.
   doblend = .true.
   imagecube = .false.
+  npix=0 ! FIXME: no check yet for the case of imagecube=true
   ngrids = 5
   return
 end subroutine SetDefaults

--- a/Init.f90
+++ b/Init.f90
@@ -103,6 +103,8 @@ subroutine Initialize()
     read (value, *) imagecube
   case("imagecube_npix","imcube_npix")
     read(value,*) npix
+  case("imagecube_filename","imcube_filename")
+    read(value,*) imagecube_filename
   case ("idum", "seed")
     read (value, *) idum
   case ("ngrids")  ! number of grids to use for the line RT, Default is 5
@@ -190,6 +192,7 @@ subroutine SetDefaults()
   cylindrical = .true.
   doblend = .true.
   imagecube = .false.
+  imagecube_filename = "imcube.fits"
   regular_grid = .false.
   npix=0 ! FIXME: no check yet for the case of imagecube=true
   ngrids = 5

--- a/InputOutput.f90
+++ b/InputOutput.f90
@@ -11,6 +11,7 @@ contains
     else
       write (*, '(a)') trim(string)
     end if
+    flush(6)
 
   end subroutine outputform
 
@@ -21,6 +22,7 @@ contains
     character(len=*), intent(in) :: string
 
     write (*, '(a)') trim(string)
+    flush(6)
 
   end subroutine output
 

--- a/InputOutput.f90
+++ b/InputOutput.f90
@@ -117,5 +117,6 @@ contains
     end if
     call output(outstr)
     call output("")
+    flush(6)
   end subroutine clock_write
 end MODULE InOut

--- a/InputOutput.f90
+++ b/InputOutput.f90
@@ -2,110 +2,118 @@
 MODULE InOut
 contains
   subroutine outputform(string, form)
-  implicit none
-  character(len=*), intent(in)           :: string
-  character(len=*), intent(in), optional :: form
+    implicit none
+    character(len=*), intent(in)           :: string
+    character(len=*), intent(in), optional :: form
 
-  if (present(form)) then
-    write(*, form) trim(string)
-  else
-    write(*, '(a)') trim(string)
-  end if
+    if (present(form)) then
+      write (*, form) trim(string)
+    else
+      write (*, '(a)') trim(string)
+    end if
 
   end subroutine outputform
 
   !-----------------------------------------------------------------------
 
   subroutine output(string)
-  implicit none
-  character(len=*), intent(in) :: string
+    implicit none
+    character(len=*), intent(in) :: string
 
-  write(*, '(a)') trim(string)
+    write (*, '(a)') trim(string)
 
   end subroutine output
 
   !-----------------------------------------------------------------------
 
   subroutine ignorestar(un)
-  implicit none
-  integer, intent(in) :: un
-  character           :: c
-  integer             :: ios
+    implicit none
+    integer, intent(in) :: un
+    character           :: c
+    integer             :: ios
 
-  do
-    read(un, '(a1)', iostat=ios) c
-    if (ios /= 0) exit
-    if (c /= '*') then
-      backspace(unit=un)
-      exit
-    end if
-  end do
+    do
+      read (un, '(a1)', iostat=ios) c
+      if (ios /= 0) exit
+      if (c /= '*') then
+        backspace (unit=un)
+        exit
+      end if
+    end do
 
   end subroutine ignorestar
 
   !-----------------------------------------------------------------------
 
   function int2string(i, form)
-  implicit none
-  integer, intent(in)                    :: i
-  character(len=*), intent(in), optional :: form
-  character(len=20)                      :: int2string
+    implicit none
+    integer, intent(in) :: i
+    character(len=*), intent(in), optional :: form
+    character(len=:), allocatable :: int2string
+    character(len=range(i) + 2) :: tmp
 
-  if (present(form)) then
-    write(int2string, form) i
-  else
-    write(int2string, *) i
-  end if
+    if (present(form)) then
+      write (tmp, form) i
+    else
+      write (tmp, *) i
+    end if
+
+    allocate (character(len=len(trim(tmp))) :: int2string)
+    int2string = trim(tmp)
 
   end function int2string
 
   !-----------------------------------------------------------------------
 
   function dbl2string(x, form)
-  implicit none
-  double precision, intent(in)           :: x
-  character(len=*), intent(in), optional :: form
-  character(len=20)                      :: dbl2string
+    implicit none
+    real(kind=8), intent(in)  :: x
+    character(len=*), intent(in), optional :: form
+    character(len=:), allocatable  :: dbl2string
+    character(len=range(x) + 2)     :: tmp
 
-  if (present(form)) then
-    write(dbl2string, form) x
-  else
-    write(dbl2string, *) x
-  end if
+    if (present(form)) then
+      write (tmp, form) x
+    else
+      write (tmp, *) x
+    end if
+
+    allocate (character(len=len(trim(tmp))) :: dbl2string)
+    dbl2string = trim(tmp)
 
   end function dbl2string
 
   !-----------------------------------------------------------------------
   subroutine clock(t, ut)
-  ! clock both the CPU-time (t) and user time (ut)
-  ! both values will be returned
+    ! clock both the CPU-time (t) and user time (ut)
+    ! both values will be returned
     implicit none
-    real(kind=8),intent(out) :: t, ut
+    real(kind=8), intent(out) :: t, ut
     integer :: count, count_rate, count_max
 
     call CPU_TIME(t)
     call SYSTEM_CLOCK(count, count_rate, count_max)
-    ut = real(count) / real(count_rate)
+    ut = real(count)/real(count_rate)
   end subroutine clock
 
   !-----------------------------------------------------------------------
   subroutine clock_write(t0, ut0, info)
-  ! write out some time information (CPU-time and user time)
-  ! t0, ut0 have to be initialised via CLOCK (see above)
-  ! info string is optional and is written just before the time information
+    ! write out some time information (CPU-time and user time)
+    ! t0, ut0 have to be initialised via CLOCK (see above)
+    ! info string is optional and is written just before the time information
     implicit none
-    real(kind=8),             intent(in)           :: t0, ut0
+    real(kind=8), intent(in)           :: t0, ut0
     character(len=*), intent(in), optional :: info
     character(len=200) :: outstr
-    real :: t1, ut1
+    real(kind=8) :: t1, ut1
 
     call clock(t1, ut1)
-    
-    write(outstr, '("time =",F10.2," s CPU-time=",F10.2," s (",F6.2," x speedup)")') &
-             ut1 - ut0, t1 - t0,(t1 - t0) / (ut1 - ut0)
+
+    write (outstr, '("time =",F10.2," s CPU-time=",F10.2," s (",F6.2," x speedup)")') &
+      ut1 - ut0, t1 - t0, (t1 - t0)/(ut1 - ut0)
 
     if (present(info)) then
-      outstr = trim(info) // " " // outstr
+      outstr = trim(info)//" "//outstr
     end if
     call output(outstr)
     call output("")

--- a/Modules.f90
+++ b/Modules.f90
@@ -44,7 +44,7 @@ module GlobalSetup
   ! the grid setup. Note that we store cos(theta) in theta, but real theta in theta_av
   real(kind=8), allocatable :: R(:), theta(:, :), R_av(:), theta_av(:, :)
   real(kind=8), allocatable :: R_sphere(:), R_av_sphere(:)
-  integer :: nR, nTheta, nlam, ilam1, ilam2, nmol, nlines, nblends, nspec
+  integer :: nR, nTheta, nlamCont, ilam1, ilam2, nmol, nlines, nblends, nspec
   real(kind=8) :: Rin, Rout, inc, Fstar_l
   real(kind=8), allocatable :: lam_cont(:), Fstar(:)
 

--- a/Modules.f90
+++ b/Modules.f90
@@ -42,7 +42,7 @@ module GlobalSetup
   integer :: structtype
 
   ! the grid setup. Note that we store cos(theta) in theta, but real theta in theta_av
-  real(kind=8), allocatable :: R(:), theta(:,:), R_av(:), theta_av(:,:)
+  real(kind=8), allocatable :: R(:), theta(:, :), R_av(:), theta_av(:, :)
   real(kind=8), allocatable :: R_sphere(:), R_av_sphere(:)
   integer :: nR, nTheta, nlam, ilam1, ilam2, nmol, nlines, nblends, nspec
   real(kind=8) :: Rin, Rout, inc, Fstar_l
@@ -53,11 +53,12 @@ module GlobalSetup
   integer, allocatable :: nImPhi(:), npoints(:)
   real(kind=8) :: vmax
 
-  ! the image cube
-  real(kind=8), allocatable :: x_im(:,:,:), y_im(:,:,:)
-  real(kind=8), allocatable :: imcube(:,:,:)
-  integer :: nint, npix, nvim
-  logical :: imagecube
+! the image cube
+  double precision, allocatable :: x_im(:, :, :), y_im(:, :, :), im_coord(:)
+  double precision, allocatable :: imcube(:, :, :)
+  integer nint, npix, nvim
+  integer(kind=4), allocatable :: imcube_hit(:, :, :)
+  logical imagecube
 
   ! store all the blackbodies
   integer :: MAXT
@@ -121,7 +122,7 @@ module GlobalSetup
     real(kind=8), allocatable :: S(:) ! dimension is wavelength
   end type Cell
 
-  type(Cell), allocatable, target :: C(:,:)  ! dimension nR,nTheta
+  type(Cell), allocatable, target :: C(:, :)  ! dimension nR,nTheta
 
   type Path
     ! minimum and maximum velocity encountered in this path
@@ -135,6 +136,9 @@ module GlobalSetup
 
     real(kind=8), allocatable :: v(:), d(:), v1(:), v2(:)
     integer, allocatable :: i(:), j(:)
+    integer*2, allocatable :: im_ixy(:, :) ! first axis =2 (x,y), second axis can theoretically go to npix*2 (all pixels),
+    ! but is likely much smaller FIXME don't know to estimate that, take npix for now
+    integer*2 :: im_npix    ! nubmer of pixels associated to that path
 
     real(kind=8), allocatable :: flux_cont(:)  !continuum contribution at each wavelength
     real(kind=8), allocatable :: cont_contr(:) !continuum contribution at each path element
@@ -150,7 +154,7 @@ module GlobalSetup
 
   !==============================
 
-  type(Path), allocatable, target :: P(:,:)
+  type(Path), allocatable, target :: P(:, :)
   type(Path), target :: path2star
   type(Molecule), allocatable :: Mol(:)
   type(Line), allocatable :: Lines(:)

--- a/Modules.f90
+++ b/Modules.f90
@@ -67,7 +67,8 @@ module GlobalSetup
   ! use a more regular grid in the image planet (i.e. no random sampling)
   logical regular_grid
   character(len=100) :: imagecube_filename
-
+  ! should the results from the continuum raytracing be used to correct the continuum for the line spectra. Default= True
+  logical :: correct_continuum
 
   ! store all the blackbodies
   integer :: MAXT

--- a/Modules.f90
+++ b/Modules.f90
@@ -53,11 +53,13 @@ module GlobalSetup
   integer, allocatable :: nImPhi(:), npoints(:)
   real(kind=8) :: vmax
 
-! the image cube
-  double precision, allocatable :: x_im(:, :, :), y_im(:, :, :), im_coord(:)
-  double precision, allocatable :: imcube(:, :, :)
-  integer nint, npix, nvim
-  integer(kind=4), allocatable :: imcube_hit(:, :, :)
+  ! the image cube
+  real(kind=8), allocatable :: x_im(:, :, :), y_im(:, :, :), im_coord(:)
+  ! FIXME: single precision should do it, to safe memory
+  real(kind=8), allocatable :: imcube(:, :, :)
+  integer npix, nvim, nlam_cube
+  real(kind=8) :: dlam_cube ! the width of the channels in the image cube
+  real(kind=8), allocatable :: lam_cube(:) ! the center wl, of the cube channels  
   ! produce an image cube
   logical imagecube
   ! use a more regular grid in the image planet (i.e. no random sampling)

--- a/Modules.f90
+++ b/Modules.f90
@@ -44,7 +44,7 @@ module GlobalSetup
   ! the grid setup. Note that we store cos(theta) in theta, but real theta in theta_av
   real(kind=8), allocatable :: R(:), theta(:, :), R_av(:), theta_av(:, :)
   real(kind=8), allocatable :: R_sphere(:), R_av_sphere(:)
-  integer :: nR, nTheta, nlamCont, ilam1, ilam2, nmol, nlines, nblends, nspec
+  integer :: nR, nTheta, nlamCont, ilam1Cont, ilam2Cont, nmol, nlines, nblends, nspec
   real(kind=8) :: Rin, Rout, inc, Fstar_l
   real(kind=8), allocatable :: lam_cont(:), Fstar(:)
 

--- a/Modules.f90
+++ b/Modules.f90
@@ -55,9 +55,9 @@ module GlobalSetup
 
   ! the image cube
   real(kind=8), allocatable :: x_im(:, :, :), y_im(:, :, :), im_coord(:)
-  ! FIXME: single precision should do it, to safe memory
-  real(kind=8), allocatable :: imcube(:, :, :)
+  real(kind=4), allocatable :: imcube(:, :, :)
   integer npix, nvim, nlam_cube
+  real(kind=8) :: delpix ! pixel size in the image plane in cm
   real(kind=8) :: pixA ! pixel area in the image plane in cgs units
   real(kind=8) :: dlam_cube ! the width of the channels in the image cube
   real(kind=8), allocatable :: lam_cube(:) ! the center wl, of the cube channels  

--- a/Modules.f90
+++ b/Modules.f90
@@ -61,6 +61,7 @@ module GlobalSetup
   real(kind=8) :: pixA ! pixel area in the image plane in cgs units
   real(kind=8) :: dlam_cube ! the width of the channels in the image cube
   real(kind=8), allocatable :: lam_cube(:) ! the center wl, of the cube channels  
+  real(kind=8), allocatable :: lamb_cube(:)
   ! produce an image cube
   logical imagecube
   ! use a more regular grid in the image planet (i.e. no random sampling)
@@ -146,7 +147,7 @@ module GlobalSetup
     integer, allocatable :: i(:), j(:)
     integer*2, allocatable :: im_ixy(:, :) ! first axis =2 (x,y), second axis can theoretically go to npix*2 (all pixels),
     ! but is likely much smaller FIXME don't know to estimate that, take npix for now
-    integer*2 :: im_npix    ! number of pixels associated to that path
+    integer :: im_npix    ! number of pixels associated to that path
 
     real(kind=8), allocatable :: flux_cont(:)  !continuum contribution at each wavelength
     real(kind=8), allocatable :: cont_contr(:) !continuum contribution at each path element

--- a/Modules.f90
+++ b/Modules.f90
@@ -58,6 +58,7 @@ module GlobalSetup
   ! FIXME: single precision should do it, to safe memory
   real(kind=8), allocatable :: imcube(:, :, :)
   integer npix, nvim, nlam_cube
+  real(kind=8) :: pixA ! pixel area in the image plane in cgs units
   real(kind=8) :: dlam_cube ! the width of the channels in the image cube
   real(kind=8), allocatable :: lam_cube(:) ! the center wl, of the cube channels  
   ! produce an image cube
@@ -145,7 +146,7 @@ module GlobalSetup
     integer, allocatable :: i(:), j(:)
     integer*2, allocatable :: im_ixy(:, :) ! first axis =2 (x,y), second axis can theoretically go to npix*2 (all pixels),
     ! but is likely much smaller FIXME don't know to estimate that, take npix for now
-    integer*2 :: im_npix    ! nubmer of pixels associated to that path
+    integer*2 :: im_npix    ! number of pixels associated to that path
 
     real(kind=8), allocatable :: flux_cont(:)  !continuum contribution at each wavelength
     real(kind=8), allocatable :: cont_contr(:) !continuum contribution at each path element

--- a/Modules.f90
+++ b/Modules.f90
@@ -153,6 +153,10 @@ module GlobalSetup
     real(kind=8), allocatable :: cont_contr(:) !continuum contribution at each path element
     real(kind=8), allocatable :: exptau_dust(:) !dust optical depth at each path element
     real(kind=8), allocatable :: S_dust(:) !dust source function at each path element
+    ! imagecube: tracks which (cube_bin, vmult-side) have already received a continuum-only
+    ! contribution for this path, to prevent double-counting when multiple blend velocity
+    ! channels map to the same cube bin.  Dim1=nlam_cube, Dim2: 1=vmult-1, 2=vmult+1.
+    logical, allocatable :: imcube_cont_done(:,:)
   end type Path
 
   type Tracer

--- a/Modules.f90
+++ b/Modules.f90
@@ -141,6 +141,7 @@ module GlobalSetup
     integer, allocatable :: npopmax(:)
     ! surface area of this path in the image and its coordinates
     real(kind=8) :: A, R1, R2, phi1, phi2, R, phi
+    ! FIXME: are vy,vy,vz really used?
     real(kind=8) :: vx, vy, vz, x, y
 
     real(kind=8), allocatable :: v(:), d(:), v1(:), v2(:)
@@ -153,10 +154,7 @@ module GlobalSetup
     real(kind=8), allocatable :: cont_contr(:) !continuum contribution at each path element
     real(kind=8), allocatable :: exptau_dust(:) !dust optical depth at each path element
     real(kind=8), allocatable :: S_dust(:) !dust source function at each path element
-    ! imagecube: tracks which (cube_bin, vmult-side) have already received a continuum-only
-    ! contribution for this path, to prevent double-counting when multiple blend velocity
-    ! channels map to the same cube bin.  Dim1=nlam_cube, Dim2: 1=vmult-1, 2=vmult+1.
-    logical, allocatable :: imcube_cont_done(:,:)
+    real(kind=8), allocatable :: imcube_cont_flux(:,:) ! to store the continuum flux added to the cube for each (cube_bin, vmult-side) for diagnostics
   end type Path
 
   type Tracer

--- a/Modules.f90
+++ b/Modules.f90
@@ -56,7 +56,7 @@ module GlobalSetup
   ! the image cube
   real(kind=8), allocatable :: x_im(:, :, :), y_im(:, :, :), im_coord(:)
   real(kind=4), allocatable :: imcube(:, :, :)
-  integer npix, nvim, nlam_cube
+  integer npix, nlam_cube
   real(kind=8) :: delpix ! pixel size in the image plane in cm
   real(kind=8) :: pixA ! pixel area in the image plane in cgs units
   real(kind=8) :: dlam_cube ! the width of the channels in the image cube

--- a/Modules.f90
+++ b/Modules.f90
@@ -58,7 +58,11 @@ module GlobalSetup
   double precision, allocatable :: imcube(:, :, :)
   integer nint, npix, nvim
   integer(kind=4), allocatable :: imcube_hit(:, :, :)
+  ! produce an image cube
   logical imagecube
+  ! use a more regular grid in the image planet (i.e. no random sampling)
+  logical regular_grid
+
 
   ! store all the blackbodies
   integer :: MAXT

--- a/Modules.f90
+++ b/Modules.f90
@@ -64,6 +64,7 @@ module GlobalSetup
   logical imagecube
   ! use a more regular grid in the image planet (i.e. no random sampling)
   logical regular_grid
+  character(len=100) :: imagecube_filename
 
 
   ! store all the blackbodies

--- a/PrepareStructure.f90
+++ b/PrepareStructure.f90
@@ -5,6 +5,9 @@ subroutine PrepareStructure()
   implicit none
   integer :: i, j, imol, ispec(nmol), ipop
 
+  call output("==================================================================")
+  call output("PrepareStructure ...")
+
   do i = 0, nR
     C(i, 0)%dens = 1d-50
   end do
@@ -31,6 +34,7 @@ subroutine PrepareStructure()
     end if
   end do
 
+  call output("Rearranging data and determine line_width ...") 
   do i = 0, nR
     call tellertje(i + 1, nR + 1)
     do j = 0, nTheta
@@ -48,6 +52,7 @@ subroutine PrepareStructure()
     end do
   end do
 
+  call output("Rearranging data and computing maximum population levels ...")
   do i = 0, nR
     call tellertje(i + 1, nR + 1)
     do j = 0, nTheta

--- a/RaytraceContinuum.f90
+++ b/RaytraceContinuum.f90
@@ -27,18 +27,21 @@ subroutine RaytraceContinuum()
   end do
   allocate (path2star%flux_cont(nlamCont))
 
-  do ilamstart = 1, nlamCont - 1
-    if (lam_cont(ilamstart + 1) > lmin) exit
-  end do
+  ilamstart = ilam1
+  ilamend = ilam2
+  ! do ilamstart = 1, nlamCont - 1
+  !   if (lam_cont(ilamstart + 1) > lmin) exit
+  ! end do
 
-  do ilamend = ilamstart, nlamCont
-    if (lam_cont(ilamend) > lmax) exit
-  end do
-  ilamend = min(ilamend, nlamCont) ! case of last point
+  ! do ilamend = ilamstart, nlamCont
+  !   if (lam_cont(ilamend) > lmax) exit
+  ! end do
+  ! ilamend = min(ilamend, nlamCont) ! case of last point
+  ! write(*,*) ilamstart,ilamend,ilam1,ilam2
 
-  call output("Raytracing the continuum for "//trim(int2string(ilamend - ilamstart, '(i5)'))//" wavelengths")
-  do ilam = ilamstart, ilamend
-    call tellertje(ilam - ilamstart + 1, ilamend - ilamstart)
+  call output("Raytracing the continuum for "//int2string(ilam2-ilam1+1, '(i5)')//" wavelengths")
+  do ilam = ilam1, ilam2
+    call tellertje(ilam - ilam1 + 1, ilam2 - ilam1+1)
     flux = 0d0
     do i = 1, ngrids
 !$OMP PARALLEL DO SCHEDULE(static,1) &

--- a/RaytraceContinuum.f90
+++ b/RaytraceContinuum.f90
@@ -22,19 +22,19 @@ subroutine RaytraceContinuum()
 
   do i = 1, ngrids
     do j = 1, npoints(i)
-      allocate (P(i, j)%flux_cont(nlam))
+      allocate (P(i, j)%flux_cont(nlamCont))
     end do
   end do
-  allocate (path2star%flux_cont(nlam))
+  allocate (path2star%flux_cont(nlamCont))
 
-  do ilamstart = 1, nlam - 1
+  do ilamstart = 1, nlamCont - 1
     if (lam_cont(ilamstart + 1) > lmin) exit
   end do
 
-  do ilamend = ilamstart, nlam
+  do ilamend = ilamstart, nlamCont
     if (lam_cont(ilamend) > lmax) exit
   end do
-  ilamend = min(ilamend, nlam) ! case of last point
+  ilamend = min(ilamend, nlamCont) ! case of last point
 
   call output("Raytracing the continuum for "//trim(int2string(ilamend - ilamstart, '(i5)'))//" wavelengths")
   do ilam = ilamstart, ilamend

--- a/RaytraceContinuum.f90
+++ b/RaytraceContinuum.f90
@@ -3,7 +3,7 @@ subroutine RaytraceContinuum()
   use Constants
   use InOut
   implicit none
-  integer          :: i, j, ilam, ilamstart, ilamend
+  integer          :: i, j, ilam
   double precision :: flux
   double precision :: time, utime
 
@@ -27,21 +27,9 @@ subroutine RaytraceContinuum()
   end do
   allocate (path2star%flux_cont(nlamCont))
 
-  ilamstart = ilam1
-  ilamend = ilam2
-  ! do ilamstart = 1, nlamCont - 1
-  !   if (lam_cont(ilamstart + 1) > lmin) exit
-  ! end do
-
-  ! do ilamend = ilamstart, nlamCont
-  !   if (lam_cont(ilamend) > lmax) exit
-  ! end do
-  ! ilamend = min(ilamend, nlamCont) ! case of last point
-  ! write(*,*) ilamstart,ilamend,ilam1,ilam2
-
-  call output("Raytracing the continuum for "//int2string(ilam2-ilam1+1, '(i5)')//" wavelengths")
-  do ilam = ilam1, ilam2
-    call tellertje(ilam - ilam1 + 1, ilam2 - ilam1+1)
+  call output("Raytracing the continuum for "//int2string(ilam2Cont-ilam1Cont+1, '(i5)')//" wavelengths")
+  do ilam = ilam1Cont, ilam2Cont
+    call tellertje(ilam - ilam1Cont + 1, ilam2Cont - ilam1Cont+1)
     flux = 0d0
     do i = 1, ngrids
 !$OMP PARALLEL DO SCHEDULE(static,1) &

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -22,11 +22,9 @@
     real(kind=8) :: vlo_eff, vhi_eff
     real(kind=8) :: wl11, wl21, wl13, wl23, flux_l1, flux_l2, flux_c
     character(len=1000) :: comment
-    character(len=500) :: imcubename
-    character(len=40) :: callerstr
-    real(kind=8) :: imcube_size
-    real(kind=8) :: delpix,starcorr    
-    real(kind=8) :: time, utime, timegap, utimegap
+    character(len=200) :: callerstr
+    real(kind=8) :: delpix,starcorr,lamgapmax    
+    real(kind=8) :: time, utime, timegap, utimegap    
 
     call output("==================================================================")
     call output("Preparing the profiles")
@@ -61,14 +59,26 @@
       call clock(time, utime)
       call output("")
       call output("Preparing the image cube ...")
+      call output("Allocating the image cube ...")
       dlam_cube = 0.5d0*(lmin + lmax)*vresolution/clight
+      write(*,*) "dlam_cube: ", dlam_cube
       nlam_cube = int((lmax - lmin)/dlam_cube) ! number of center wl-points
       allocate (imcube(npix, npix, nlam_cube))      
       allocate (lam_cube(nlam_cube))
+      allocate (lamb_cube(nlam_cube+1))
       ! for convenience store the center wl points
+      ! lmin should be the first center
       do i = 1, nlam_cube
-        lam_cube(i) = lmin + dlam_cube*(i - 1) + dlam_cube/2.
+        lam_cube(i) = lmin + dlam_cube*(i - 1)
       end do
+
+      ! store the edge wl points      
+      do i = 1, nlam_cube+1
+        lamb_cube(i) = (lmin - dlam_cube/2d0) + dlam_cube*(i-1)
+      end do
+      write(*,*) lam_cube
+      write(*,*) lamb_cube
+
 
       imcube = 0d0      
       allocate (im_coord(npix))
@@ -76,14 +86,16 @@
       pixA=delpix**2
       starcorr=path2star%A/pixA
       ! create the center coordinates for the pixels
+      call output("Calculate pixel coordinates ...")
       do i = 1, npix ! center coordinates of pixels in cm
         im_coord(i) = delpix/2d0 + delpix*(i - 1) - Rout*AU
       end do
             
       ! map the paths to the pixel, need to do it for each grid
-      do i = 1, ngrids
-        call map_pixels_to_path(i, npoints(i))
-      end do
+      !do i = 1, ngrids
+      call output("map grid "//int2string(1, '(i7)')//" to pixels")
+      call map_pixels_to_path(1, npoints(1))
+      !end do
 
       call output("Image cube has "//trim(int2string(nlam_cube, '(i7)'))//" channels (dlam="//trim(dbl2string(dlam_cube, '(F11.4)'))//") and "//trim(int2string(npix*npix, '(i7)'))//" pixels.")
       call output("Image cube size: "//trim(dbl2string(sizeof(imcube)/1.e9, '(F11.4)'))//" GB")
@@ -162,46 +174,48 @@
           ilam_cube_end = 0
 
           call clock(timegap, utimegap)
-          do i = 1, nlam_cube
-            if ((lam_cube(i) > lcmin .and. lam_cube(i) < Bl%lmin) .or. &
-                (iblends == nblends .and. lam_cube(i) > Bl%lmax)) then ! this is for the end
+
+          ! here lcmin is the wl that was done in the last blend, 
+          ! Something is fishy here, bzt Bl%lmax is not the maximum wavelength that is actually done
+          lamgapmax=lam*sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
+          do i = 1, nlam_cube ! check if lcmin is  not in the current cube bin            
+            if ((lamb_cube(i+1) > lcmin .and. lamb_cube(i+1) < Bl%lmin) .or. &
+                (iblends == nblends .and. lamb_cube(i) > lamgapmax)) then ! this is for the end
               ilam_cube_start = min(ilam_cube_start, i)
               ilam_cube_end = max(ilam_cube_end, i)
             end if
           end do
-          ! I have some gap
-          if (ilam_cube_start <= ilam_cube_end) then
+          ! I have some gap          
+          if (ilam_cube_start <= ilam_cube_end) then            
             call output("  Fill imcube gap from lam "//dbl2string(lam_cube(ilam_cube_start))//" to"//dbl2string(lam_cube(ilam_cube_end))//" with continuum.")          
+            !write(*,*) Bl%lmin, Bl%lmax,lamgapmax, lcmin, lamb_cube(ilam_cube_start),lam_cube(ilam_cube_start),lam_cube(ilam_cube_end)
             do i = ilam_cube_start, ilam_cube_end
-              if ((lam_cube(i) > lcmin .and. lam_cube(i) < Bl%lmin) .or. &
-                  (iblends == nblends .and. lam_cube(i) > Bl%lmax)) then ! this is for the end
+              !if ((lam_cube(i) > lcmin .and. lam_cube(i) < Bl%lmin) .or. &
+              !    (iblends == nblends .and. lam_cube(i) > Bl%lmax)) then ! this is for the end
                 ilam_cube_gap = 1
                 do while (lam_cube(i) > lam_cont(ilam_cube_gap + 1) .and. ilam_cube_gap < nlamCont)
                   ilam_cube_gap = ilam_cube_gap + 1
                 end do
                 call InterpolateLam(lam_cube(i), ilam_cube_gap)
-                do igrid = 1,ngrids
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP PRIVATE(j,PP, flux0,vmult) &
 !$OMP SHARED(P, npoints, lam_cube, i, igrid, ngrids)
 !$OMP DO SCHEDULE(dynamic,1)
-                  do j = 1, npoints(igrid)  ! just do it for the first grid
-                    PP => P(igrid, j)
-                    call ContContrPath(PP, flux0)
-                    flux0=flux0/real(ngrids)
-                    do vmult=-1,1,2
-                      call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, vmult, "continuum in gap")                  
-                    end do
+                do j = 1, npoints(1)  ! just do it for the first grid for imagecube
+                  PP => P(1, j)
+                  call ContContrPath(PP, flux0)
+                  do vmult=-1,1,2
+                    call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, vmult, "continuum in gap")                  
                   end do
+                end do
 !$OMP END DO
 !$OMP END PARALLEL
-                enddo
                 ! do the star, as there are no lines, nb = 0
                 PP => path2star                
-                call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, 0)    
-                ! for the star we correct the area as the pixel is usuall much larger than the star            
-                call AddImage(0, lam_cube(i), flux0*PP%A*starcorr, PP, 1, "trace star")
-              end if
+                call Trace2StarLines(PP, flux0, 0, imol_blend, v_blend, 0)    
+                ! for the star we correct the area as the pixel is usually much larger than the star            
+                call AddImage(0, lam_cube(i), flux0*PP%A*starcorr, PP, 1, "trace star gap")
+              !end if
             end do
             call clock_write(timegap, utimegap,"  Fill imcube gap: ")
           end if
@@ -210,7 +224,7 @@
         if (iblends == 1) then
           call output("  First line blend ("//trim(int2string(nb, '(i4)'))//" lines at lamcenter="//(dbl2string(Bl%lam, '(F10.3)'))//" micron)")
         end if
-
+        
 
         ilam = ilam1Cont
         do while (lam > lam_cont(ilam + 1) .and. ilam < nlamCont)
@@ -237,7 +251,10 @@
           ilam1Cont = ilam
         end if
 
+        write(*,*) "Blend: ",iblends,lcmin, Bl%lmin, Bl%lmax, lam, nb,lmin_next
+
         lcmin = Bl%lmax
+        write(*,*) "Blend: ",iblends,lcmin, Bl%lmin, Bl%lmax, lam, nb,lmin_next
 
         call InterpolateLam(lam, ilam)
         do i = 0, nR
@@ -254,7 +271,12 @@
         flux2 = 0d0
 
         ! randomly select a grid.
-        i = int(ran1(idum)*real(ngrids) + 1)
+        if (imagecube) then 
+          i=1
+        else
+          i = int(ran1(idum)*real(ngrids) + 1)
+        endif
+        
 
         ! FIXME: check parallel implementation for imagecube
 !$OMP PARALLEL IF(.true.) &
@@ -330,11 +352,17 @@
                     end do
                     if (gas) then
                       call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
+                      if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, callerstr)
                     else
                       flux0 = flux_c
+                      !write (callerstr, "(A,' ' ,i5,A,F10.3,A,F10.3)") "call nb ", iblends,"lmin:",lmin_next,"lv:",lam_velo
+                      ! FIXME: It cann happen hat somehoe a iv of several blends produces a continuum in the same imcube channel
+                      ! hence the continuum is contouned multipe times, the reason is the if (gas) thingy  
+                      if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, "cont")
                     end if
                     flux4(iv) = flux4(iv) + flux0*PP%A/2d0
-                    if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, "call nb")
+                    !write (callerstr, "(A,' ' ,i5,A,F10.3,A,F10.3)") "call nb ", iblends,"lmin:",lmin_next,"lv:",lam_velo
+                    !if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, callerstr)
                   end do
                   ! channel fully outside the line, so just add the continuum contribution
                 else if (((real(iv) + 0.5d0)*vresolution > PP%vmax(LL%imol) .and. &
@@ -348,7 +376,7 @@
                     ! FIXME: callerstring is only for debugging, remove it
                     write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else if", iv, vmult
                     if (imagecube) then
-                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, callerstr)
+                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, "cont")
                     end if
                   end do
                   ! channel covers single line (not blended)
@@ -366,15 +394,19 @@
               end if
             end do
           else
-            !write(*,*) "call not dotit"
+            !write(*,*) "call not doit", not populated
+            ! not sure why here we do not use vmult treatment
             flux0 = flux_c
             flux4(Bl%nvmin:Bl%nvmax) = flux4(Bl%nvmin:Bl%nvmax) + flux0*PP%A
-            if (imagecube) then
-              do iv = Bl%nvmin, Bl%nvmax
-                do vmult = -1,1,2
-                  call AddImage(iv, lam, flux0*PP%A, PP, vmult, "call not doit")
-                enddo
-              end do
+            if (imagecube.and..false.) then ! do the vmult treatment for the image cube, important where the flux is
+              do vmult = -1, 1, 2
+                do iv = Bl%nvmin, Bl%nvmax
+                  lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
+                  if (lam_velo > lmin_next) then
+                    call AddImage(iv, lam, flux0*PP%A, PP, vmult, "call not doit")
+                  endif
+                end do
+              end do 
             end if
           end if
         end do
@@ -405,42 +437,42 @@
         flux1 = 0d0
         flux3 = 0d0
 
-        f = sqrt((1d0 + real(Bl%nvmin)*vresolution/clight)/(1d0 - real(Bl%nvmin)*vresolution/clight))
-        wl11 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-        ! wl11 can be > 1 if nv*vresolution is wider than the spacing between the continuum points.
-        ! So the continuum grid is too fine, just assume the nearest continuum point then.
-        ! > 1 would mean extrapolation, but in some cases that ends in NaN, limiting it to 1 means, no extrapolation
-        wl11 = min(1d0, max(0d0, wl11))
-        wl21 = 1d0 - wl11
+        ! f = sqrt((1d0 + real(Bl%nvmin)*vresolution/clight)/(1d0 - real(Bl%nvmin)*vresolution/clight))
+        ! wl11 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+        ! ! wl11 can be > 1 if nv*vresolution is wider than the spacing between the continuum points.
+        ! ! So the continuum grid is too fine, just assume the nearest continuum point then.
+        ! ! > 1 would mean extrapolation, but in some cases that ends in NaN, limiting it to 1 means, no extrapolation
+        ! wl11 = min(1d0, max(0d0, wl11))
+        ! wl21 = 1d0 - wl11
 
-        f = sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
-        wl13 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-        ! see above wl11
-        wl13 = min(1d0, max(0d0, wl13))
-        wl23 = 1d0 - wl13
+        ! f = sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
+        ! wl13 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+        ! ! see above wl11
+        ! wl13 = min(1d0, max(0d0, wl13))
+        ! wl23 = 1d0 - wl13
 
-        flux_l1 = 0d0
-        flux_l2 = 0d0
-        do k = 1, ngrids
-          do j = 1, npoints(k)
-            PP => P(k, j)
-            flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A/real(ngrids)
-            flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A/real(ngrids)
-          end do
-        end do
-        PP => path2star
+        ! flux_l1 = 0d0
+        ! flux_l2 = 0d0
+        ! do k = 1, ngrids
+        !   do j = 1, npoints(k)
+        !     PP => P(k, j)
+        !     flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A/real(ngrids)
+        !     flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A/real(ngrids)
+        !   end do
+        ! end do
+        ! PP => path2star
 
-        flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A
-        flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A
+        ! flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A
+        ! flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A
 
-        flux1 = flux_l1**wl11*flux_l2**wl21
-        flux3 = flux_l1**wl13*flux_l2**wl23
+        ! flux1 = flux_l1**wl11*flux_l2**wl21
+        ! flux3 = flux_l1**wl13*flux_l2**wl23
 
-        do iv = Bl%nvmin, Bl%nvmax
-          fc = flux1 + (flux3 - flux1)*real(iv - Bl%nvmin)/real(Bl%nvmax - Bl%nvmin)
-          flux(iv) = flux(iv) - flux2 + fc
-          flux_cont(iv) = fc
-        end do
+        ! do iv = Bl%nvmin, Bl%nvmax
+        !   fc = flux1 + (flux3 - flux1)*real(iv - Bl%nvmin)/real(Bl%nvmax - Bl%nvmin)
+        !   flux(iv) = flux(iv) - flux2 + fc
+        !   flux_cont(iv) = fc
+        ! end do
 
         if (Bl%n == 1) then
           comment = trim(Mol(Bl%L(1)%imol)%name)//"  up: "//trim(int2string(Bl%L(1)%jup, '(i5)')) &
@@ -485,7 +517,6 @@
         Bl%F = Bl%F*1d-3/(distance*parsec)**2
         write (21, *) lam_w, Bl%F, lam_w_min, lam_w_max, trim(comment)
 
-        ! has to be here, (i.e. before lmin_next is set, and beofre BL%next is done)
         lmin_next = max(lmin_next, lam_velo)
 
       end if ! if(lam>lmin.and.lam<lmax)
@@ -499,7 +530,7 @@
     if (imagecube) then
       call output("")
       call output("Writing image cube to file imcube.fits ...")
-      call writefitsfile(trim(imagecube_filename), imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin+dlam_cube/2d0, lmin+dlam_cube/2d0, .true.)
+      call writefitsfile(trim(imagecube_filename), imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin, lmin, .true.)
       call output("")      
     end if
 
@@ -808,6 +839,7 @@
   subroutine InterpolateLam(lam0, ilam)
     use GlobalSetup
     use Constants
+    use InOut
     implicit none
     real(kind=8), intent(in) :: lam0
     integer, intent(in) :: ilam
@@ -815,6 +847,10 @@
     real(kind=8) :: wl1, wl2, w1, w2, x1, x2
     integer :: i, j
 
+    if (lam0 < lam_cont(ilam) .or. lam0 > lam_cont(ilam + 1)) then
+      call output("Error: InterpolateLam called with lam0 outside the range of the continuum grid points. This should not happen. Check the code.")
+      stop
+    end if
     w1 = (lam_cont(ilam + 1) - lam0)/(lam_cont(ilam + 1) - lam_cont(ilam))
     w2 = 1d0 - w1
     wl1 = log10(lam_cont(ilam + 1)/lam0)/log10(lam_cont(ilam + 1)/lam_cont(ilam))
@@ -859,7 +895,7 @@
 
     integer :: i, j, ipath, iminpath, maxnpixpath
 
-    !call clock(time, utime)
+    call clock(time, utime)
 
     ! If already allocated this was done already (same grid igrid is used again), no need to map things again
     if (allocated(P(igrid, 1)%im_ixy)) return
@@ -889,6 +925,7 @@
     end do
 
     do i = 1, npix
+      call tellertje(i,npix)
       im_x = im_coord(i)
       ! only care about the positive half
       do j = int(npix/2 + 1), npix
@@ -919,7 +956,7 @@
 
     ! now there will be paths with no pixel assigned as in case for Paths being
     ! close to each other the pixel is only assigned to the closest one
-    ! so simply go through the paths without pixels, and assign the closest one.
+    ! so simply go through the paths without pixels, and assign the closest pixel .
 
     do ipath = 1, npath
       p0 => P(igrid, ipath)
@@ -942,7 +979,7 @@
       !write (*, *) path2star%x, path2star%y, path2star%im_ixy(:, 1)
     end if
 
-    !call clock_write(time, utime, "map_pixels_to_path:")
+    call clock_write(time, utime, "map_pixels_to_path:")
     ! some log output and set the correction factor
 
     ! p0 => path2star
@@ -960,6 +997,7 @@
     ! wavelength grid and accumulates flux into imcube.
     use GlobalSetup
     use Constants
+    use InOut
     implicit none
     integer, intent(in) :: iv
     real(kind=8), intent(in) :: lam_blend
@@ -968,21 +1006,37 @@
     type(Path), intent(in) :: p0
     character(len=*), intent(in) :: caller        ! just for logging, can be removed
     integer :: ix, iy, ipix, ivcube
-    real(kind=8) :: fluxperpix, lam_velo,singlepixcorr
+    real(kind=8) :: fluxperpix, lam_velo
 
+    ! the cube goes strictly from lmin (channel centers) to lmax, but parts of a bleand can be outside    
     ! compute absolute wavelength for this channel and map to global cube index
     lam_velo = lam_blend*sqrt((1d0 + real(iv)*vresolution/clight)/ &
                               (1d0 - real(iv)*vresolution/clight))
-    ivcube = nint((lam_velo - lam_cube(1))/dlam_cube) + 1
+    if (lam_velo<lamb_cube(1) .or. lam_velo>lamb_cube(nlam_cube+1)) then
+      ! this can happen for the channels at the edge of the blend, just ignore those.
+      return
+    end if
+
+    ivcube = idnint((lam_velo - lam_cube(1))/dlam_cube) + 1
+    ! Sanity check
+    if (lam_velo<lamb_cube(ivcube).or.lam_velo>lamb_cube(ivcube+1)) then
+      write(*,*) ivcube,lam_velo, lamb_cube(ivcube), lam_cube(ivcube),lamb_cube(ivcube+1)
+      call output("Warning: velocity channel iv="//trim(int2string(iv, '(i5)'))// &
+                  " at lam_velo="//trim(dbl2string(lam_velo, '(f15.8)'))// &
+                  " is outside of the cube limits. Skipping this channel for the image cube. Caller: "//trim(caller))
+      stop
+    end if
     !write(*,*) caller," ", lam_blend,lam_velo,lmin,ivcube
+    ! some parts of the line can be outside of the cube limits, we ignore those.
     if (ivcube < 1 .or. ivcube > nlam_cube) return
 
+    
     fluxperpix = flux0/p0%im_npix    
 
     do ipix = 1, p0%im_npix
 
       ix = p0%im_ixy(1, ipix)
-      iy = p0%im_ixy(2, ipix)
+      iy = p0%im_ixy(2, ipix) 
 
       ! assume here x and y = 0 at the center of the image
       if (vmult < 0) then
@@ -991,5 +1045,11 @@
 
       imcube(iy, ix, ivcube) = imcube(iy, ix, ivcube) + fluxperpix ! P%y (Vertical) seems to be along the major axis - make it x
     end do
+
+    ! if (ivcube==57) then
+    !   !write(*,*) lamb_cube(57),lam_cube(57),lamb_cube(58)
+    !   write(*,*) "caller: ", trim(caller), " iv: ", iv, " lam_blend: ", lam_blend, " lam_velo: ", lam_velo, " ivcube: ", ivcube, vmult,p0%im_npix,fluxperpix,p0%x,p0%y,ix,iy      
+    ! end if  
+
     return
   end subroutine AddImage

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -8,9 +8,10 @@
     integer(kind=4) :: counts, count_rate, count_max
     integer, external :: OMP_GET_THREAD_NUM
     integer, allocatable :: imol_blend(:), count(:)
+    integer :: ilam_cube_gap, ilam_cube_start, ilam_cube_end
     real(kind=8), allocatable :: v_blend(:), flux4(:)
     real(kind=8) :: lam, flux0, starttime, stoptime, fact, lcmin
-    real(kind=8) :: lmin_next, lam_velo, lam_velo_imcube
+    real(kind=8) :: lmin_next, lam_velo
     real(kind=8), allocatable :: flux(:), flux_cont(:)
     type(Path), pointer :: PP
     type(Line) :: LL
@@ -23,8 +24,9 @@
     character(len=1000) :: comment
     character(len=500) :: imcubename
     character(len=40) :: callerstr
+    real(kind=8) :: imcube_size
     real(kind=8) :: delpix
-    real(kind=8) :: time, utime
+    real(kind=8) :: time, utime, timegap, utimegap
 
     call output("==================================================================")
     call output("Preparing the profiles")
@@ -41,6 +43,8 @@
     open (unit=21, file=output_lineFluxFile, RECL=1500)
     write (21, '("# lam[mu]   Fline[W/m^2]    lmin[mu]    lmax[mu]    comment")')
 
+    ! number of velocity points is determined by the width of the broadest possible line
+    ! which is given by vmax (which should be the max projected Keplerian velocity)
     nv = int(vmax*1.1/vresolution) + 1
     nvprofile = int(vmax*vres_mult/vresolution)
 
@@ -54,19 +58,39 @@
     allocate (count(nmol))
 
     if (imagecube) then
-      allocate (imcube(npix, npix, nvmin:nvmax))
-      allocate (imcube_hit(npix, npix, nvmin:nvmax))
+      call clock(time, utime)
+      call output("")
+      call output("Preparing the image cube ...")
+      dlam_cube = 0.5d0*(lmin + lmax)*vresolution/clight
+      nlam_cube = int((lmax - lmin)/dlam_cube) ! number of center wl-points
+      allocate (imcube(npix, npix, nlam_cube))      
+      allocate (lam_cube(nlam_cube))
+      ! for convenience store the center wl points
+      do i = 1, nlam_cube
+        lam_cube(i) = lmin + dlam_cube*(i - 1) + dlam_cube/2.
+      end do
+
+      imcube = 0d0      
       allocate (im_coord(npix))
-      write(*,*) "Rout",Rout
       delpix = 2.d0*Rout*AU/real(npix)
       ! create the center coordinates for the pixels
       do i = 1, npix ! center coordinates of pixels in cm
         im_coord(i) = delpix/2d0 + delpix*(i - 1) - Rout*AU
       end do
+            
+      ! map the paths to the pixel, need to do it for each grid
+      do i = 1, ngrids
+        call map_pixels_to_path(i, npoints(i))
+      end do
+
+      call output("Image cube has "//trim(int2string(nlam_cube, '(i7)'))//" channels and "//trim(int2string(npix*npix, '(i7)'))//" pixels.")
+      call output("Image cube size: "//trim(dbl2string(sizeof(imcube)/1.e9, '(F11.4)'))//" GB")
+      call clock_write(time, utime, "Prepare image cube: ")
     end if
-    
+
     lam = lmin
     ilam1Cont = 1
+
     do while (lam > lam_cont(ilam1Cont + 1) .and. ilam1Cont < nlamCont)
       ilam1Cont = ilam1Cont + 1
     end do
@@ -95,7 +119,7 @@
     call output("==================================================================")
 
     call clock(time, utime)
-  
+
     call SYSTEM_CLOCK(counts, count_rate, count_max)
     starttime = DBLE(counts)/DBLE(count_rate)
 
@@ -110,18 +134,13 @@
       nltot = nltot + Bl%n
       if (iblends < nblends) Bl => Bl%next
     end do
-    call output("Total number of wl/velocity points: "//trim(int2string(nltot, '(i7)')))
+    !call output("Total number of wl/velocity points: "//trim(int2string(nltot, '(i7)')))
 
     Bl => Blends
     do iblends = 1, nblends
-      if (imagecube) then
-        imcube = 0d0 ! FIXME: in the end I want only one cube, not for each blend, I think that should be moved outside of the blends loop (like flux)
-        imcube_hit = 0
-      end if
       flux = 0d0
 
       nb = Bl%n
-      if (iblends == 1) call output("First line blend ("//trim(int2string(nb, '(i4)'))//" lines)")
 
       do ib = 1, nb
         imol_blend(ib) = Bl%L(ib)%imol
@@ -135,13 +154,64 @@
       if (lam > lmin .and. lam < lmax) then
         nl = nl + nb
 
+        ! make sure that we do not end up with empy channels.
+        if (imagecube) then
+          ilam_cube_start = nlam_cube
+          ilam_cube_end = 0
+
+          call clock(timegap, utimegap)
+          do i = 1, nlam_cube
+            if ((lam_cube(i) > lcmin .and. lam_cube(i) < Bl%lmin) .or. &
+                (iblends == nblends .and. lam_cube(i) > Bl%lmax)) then ! this is for the end
+              ilam_cube_start = min(ilam_cube_start, i)
+              ilam_cube_end = max(ilam_cube_end, i)
+            end if
+          end do
+          ! I have some gap
+          if (ilam_cube_start <= ilam_cube_end) then
+            call output("  Fill imcube gap from lam "//dbl2string(lam_cube(ilam_cube_start))//" to"//dbl2string(lam_cube(ilam_cube_end))//" with continuum.")          
+            do i = ilam_cube_start, ilam_cube_end
+              if ((lam_cube(i) > lcmin .and. lam_cube(i) < Bl%lmin) .or. &
+                  (iblends == nblends .and. lam_cube(i) > Bl%lmax)) then ! this is for the end
+                ilam_cube_gap = 1
+                do while (lam_cube(i) > lam_cont(ilam_cube_gap + 1) .and. ilam_cube_gap < nlamCont)
+                  ilam_cube_gap = ilam_cube_gap + 1
+                end do
+                call InterpolateLam(lam_cube(i), ilam_cube_gap)
+!$OMP PARALLEL DEFAULT(NONE) &
+!$OMP PRIVATE(j, PP, flux0) &
+!$OMP SHARED(P, npoints, lam_cube, i)
+!$OMP DO SCHEDULE(dynamic,1)
+                do j = 1, npoints(1)  ! just do it for the first grid
+                  PP => P(1, j)
+                  call ContContrPath(PP, flux0)
+                  call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, 1, "continuum in gap")
+                  ! because of symmetry
+                  call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, -1, "continuum in gap")
+                end do
+!$OMP END DO
+!$OMP END PARALLEL
+                PP => path2star
+                call ContContrPath(PP, flux0)
+                call AddImage(0, lam_cube(i), flux0*PP%A, PP, 1, "star in gap")
+              end if
+            end do
+            call clock_write(timegap, utimegap,"  Fill imcube gap: ")
+          end if
+        end if
+
+        if (iblends == 1) then
+          call output("  First line blend ("//trim(int2string(nb, '(i4)'))//" lines at lamcenter="//(dbl2string(Bl%lam, '(F10.3)'))//" micron)")
+        end if
+
+
         ilam = ilam1Cont
         do while (lam > lam_cont(ilam + 1) .and. ilam < nlamCont)
           ilam = ilam + 1
           if (ilam == nlamCont) exit
         end do
-
-        ! that writes out continuum only points for the spectrum.
+        ! that writes out continuum only points for the spectrum, however, onlz the points available
+        ! which could be only 1
         if (ilam > ilam1Cont) then
           do k = ilam1Cont + 1, ilam
             if (lam_cont(k) > lcmin .and. lam_cont(k) < Bl%lmin) then
@@ -159,6 +229,7 @@
           end do
           ilam1Cont = ilam
         end if
+
         lcmin = Bl%lmax
 
         call InterpolateLam(lam, ilam)
@@ -175,9 +246,8 @@
 
         flux2 = 0d0
 
-			  ! randomly select a grid. 
+        ! randomly select a grid.
         i = int(ran1(idum)*real(ngrids) + 1)
-        if (imagecube) call map_pixels_to_path(i, npoints(i))
 
         ! FIXME: check parallel implementation for imagecube
 !$OMP PARALLEL IF(.true.) &
@@ -196,7 +266,7 @@
         flux4(:) = 0d0
 !$OMP DO SCHEDULE(dynamic,1)
         do j = 1, npoints(i)
-          if (iblends == 1) call tellertje(j, npoints(i))
+          !if (iblends == 1) call tellertje(j, npoints(i))
           PP => P(i, j)
 
           !write(88,*) i,j,PP%x/AU,PP%y/AU
@@ -228,6 +298,7 @@
                   ! side -- each weighted by half the solid-angle area (PP%A/2).
                   !   vmult = -1 : approaching (blueshifted) side, gas velocities in [-vmax, -vmin]
                   !   vmult = +1 : receding  (redshifted)  side, gas velocities in [ vmin,  vmax]
+                  ! Note that to make this work the grid has to be prepared properly (i.e. only have positive y values)
                   ! Thanks to Claude
                   do vmult = -1, 1, 2
                     doit_ib(1:nb) = doit_ib0(1:nb)
@@ -256,9 +327,9 @@
                       flux0 = flux_c
                     end if
                     flux4(iv) = flux4(iv) + flux0*PP%A/2d0
-                    if (imagecube) call AddImage(iv, flux0*PP%A/2d0, PP, vmult, "call nb")
+                    if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, "call nb")
                   end do
-                ! channel fully outside the line, so just add the continuum contribution 
+                  ! channel fully outside the line, so just add the continuum contribution
                 else if (((real(iv) + 0.5d0)*vresolution > PP%vmax(LL%imol) .and. &
                           (real(iv) - 0.5d0)*vresolution > PP%vmax(LL%imol)) &
                          .or. ((real(iv) + 0.5d0)*vresolution < PP%vmin(LL%imol) .and. &
@@ -270,10 +341,10 @@
                     ! FIXME: callerstring is only for debugging, remove it
                     write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else if", iv, vmult
                     if (imagecube) then
-                      call AddImage(iv*vmult, flux0*PP%A/2d0, PP, vmult, callerstr)
+                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, callerstr)
                     end if
                   end do
-                ! channel covers single line (not blended)
+                  ! channel covers single line (not blended)
                 else
                   doit_ib = .true.
                   call TraceFluxLines(PP, flux0, iv, vmult, imol_blend, v_blend, doit_ib, nb, 1)
@@ -281,7 +352,7 @@
                     flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0
                     write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else", iv, vmult
                     if (imagecube) then
-                      call AddImage(iv*vmult, flux0*PP%A/2d0, PP, vmult, callerstr)
+                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, callerstr)
                     end if
                   end do
                 end if
@@ -292,7 +363,7 @@
             flux4(Bl%nvmin:Bl%nvmax) = flux4(Bl%nvmin:Bl%nvmax) + flux0*PP%A
             if (imagecube) then
               do iv = Bl%nvmin, Bl%nvmax
-                call AddImage(iv, flux0*PP%A, PP, 1, "call not doit")
+                call AddImage(iv, lam, flux0*PP%A, PP, 1, "call not doit")
               end do
             end if
           end if
@@ -301,13 +372,13 @@
 !$OMP CRITICAL
         flux(:) = flux(:) + flux4(:)
 !$OMP END CRITICAL
-        deallocate (doit_ib0)        
+        deallocate (doit_ib0)
         deallocate (doit_ib)
         deallocate (flux4)
 !$OMP FLUSH
 !$OMP END PARALLEL
         PP => path2star
-        ! do the star 
+        ! do the star
         if (.not. allocated(PP%im_ixy)) allocate (PP%im_ixy(2, 1))
         do iv = Bl%nvmin, Bl%nvmax
           if (nb > 1) then  ! FIXME: this if seems to be unnecessary
@@ -317,7 +388,7 @@
             call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
             flux(iv) = flux(iv) + flux0*PP%A
           end if
-          if (imagecube) call AddImage(iv, flux0*PP%A, PP, 1, "trace star")
+          if (imagecube) call AddImage(iv, lam, flux0*PP%A, PP, 1, "trace star")
         end do
         flux2 = flux2 + flux0*PP%A
 
@@ -405,33 +476,6 @@
         write (21, *) lam_w, Bl%F, lam_w_min, lam_w_max, trim(comment)
 
         ! has to be here, (i.e. before lmin_next is set, and beofre BL%next is done)
-        if (imagecube) then
-          ! do it similar to the flux output ... find the index where we actuall start (have data)
-          do iv = Bl%nvmin, Bl%nvmax
-            lam_velo_imcube = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
-            if (lam_velo_imcube > lmin_next) exit
-          end do
-          !write(*,*) iv,Bl%nvmax,nvmin,nvmax,lmin_next,lam_velo
-          imcubename = "imcube"//trim(int2string(iblends, '(i0.10)'))//".fits"
-          call output("Writing image cube to file " // trim(imcubename))
-          !write(*,*) imcube(12,60,-1),imcube(12,42,-1),imcube(12,60,1),imcube(12,42,1)
-          ! currently this is per blend
-          !call writefitsfile(imcubename,imcube*1e23/(distance*parsec)**2,nvmax-nvmin+1,npix)
-          !lam_velo=lam*sqrt((1d0+real(Bl%nvmin)*vresolution/clight)/(1d0-real(Bl%nvmin)*vresolution/clight))
-
-          ! to avoid nan, assumes that the pixels the should be hit are really hit
-          WHERE (imcube_hit < 1) imcube_hit = 1
-
-          call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2,nvmax-iv+1,npix,Bl%lam,lam_velo_imcube,.false.)
-
-          !imcubename = "imcube_wl"//trim(int2string(iblends, '(i0.10)'))//".fits"
-          !call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2,nvmax-iv+1,npix,Bl%lam,lam_velo_imcube,.true.)
-          !call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2/imcube_hit(:,:,iv:nvmax),nvmax-iv+1,npix,Bl%lam,lam_velo_imcube)
-
-          !imcubename = "imcube_hit"//trim(int2string(iblends, '(i0.10)'))//".fits"
-          !call writefitsfile(imcubename,imcube_hit,nvmax-iv+1,npix,npix,Bl%lam,lam_velo_imcube)
-        end if
-
         lmin_next = max(lmin_next, lam_velo)
 
       end if ! if(lam>lmin.and.lam<lmax)
@@ -439,9 +483,15 @@
       if (iblends < nblends) Bl => Bl%next
 
       call tellertje_time(iblends, nblends, nl, nltot, starttime)
-!                call tellertje_time(iblends,nblends,iblends,nblends,starttime)
 
     end do
+
+    if (imagecube) then
+      call output("")
+      call output("Writing image cube to file imcube.fits ...")
+      call writefitsfile("imcube.fits", imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin+dlam_cube/2d0, lmin+dlam_cube/2d0, .true.)
+      call output("")      
+    end if
 
     ilam = ilam + 1
     do while (ilam <= nlamCont)
@@ -486,13 +536,13 @@
     use GlobalSetup
     use Constants
     implicit none
-    
-    type(Path),intent(inout) :: p0
-    real(kind=8),intent(out) :: flux
+
+    type(Path), intent(inout) :: p0
+    real(kind=8), intent(out) :: flux
 
     integer :: i, j, k
     real(kind=8) :: tau, fact, S, tau_dust, tau_d, tau_tot
-  
+
     type(Cell), pointer :: CC
 
     fact = 1d0
@@ -536,18 +586,18 @@
     use GlobalSetup
     use Constants
     implicit none
-    
-    type(Path),intent(in) :: p0
-    real(kind=8),intent(out) :: flux
-    integer,intent(in) :: ii,vmult,imol_blend(nb)
-    real(kind=8),intent(in) :: v_blend(nb)
-    logical,intent(in) :: doit(nb)
-    integer,intent(in) :: nb, ib0
-    
+
+    type(Path), intent(in) :: p0
+    real(kind=8), intent(out) :: flux
+    integer, intent(in) :: ii, vmult, imol_blend(nb)
+    real(kind=8), intent(in) :: v_blend(nb)
+    logical, intent(in) :: doit(nb)
+    integer, intent(in) :: nb, ib0
+
     integer :: i, j, k, imol
     real(kind=8) :: tau, exptau, fact, prof, S, tau_gas, tau_dust, tau_d, tau_tot
     double precision :: v
-    integer :: jj,ib
+    integer :: jj, ib
     type(Cell), pointer :: CC
     logical :: gas
     real(kind=8) :: rj
@@ -620,16 +670,16 @@
   subroutine Trace2StarLines(p0, flux, ii, imol_blend, v_blend, nb)
     use GlobalSetup
     use Constants
-    implicit none  
-    type(Path),intent(in) :: p0
-    real(kind=8),intent(out) :: flux
-    integer,intent(in) :: ii, imol_blend(nb)
-    real(kind=8),intent(in) :: v_blend(nb)
-    integer,intent(in) :: nb
+    implicit none
+    type(Path), intent(in) :: p0
+    real(kind=8), intent(out) :: flux
+    integer, intent(in) :: ii, imol_blend(nb)
+    real(kind=8), intent(in) :: v_blend(nb)
+    integer, intent(in) :: nb
 
-    integer :: i, j, k, imol 
+    integer :: i, j, k, imol
     real(kind=8) :: tau, prof
-    integer :: ib,jj  
+    integer :: ib, jj
     type(Cell), pointer :: CC
 
     tau = 0d0
@@ -666,10 +716,15 @@
 
     integer, intent(in) :: nv
     integer, intent(out) :: maxblend, nvmin0, nvmax0
-    
+
     integer :: i, iv, j
-    real(kind=8) :: maxvshift, maxmult, v,f
+    real(kind=8) :: maxvshift, maxmult, v, f
     type(Blend), pointer :: Bl
+    real(kind=8) :: time,utime
+
+    call clock(time,utime)
+    call output("")
+    call output("Determining blends...")        
 
     maxvshift = 2d0*real(nv)*vresolution
     maxmult = sqrt((1d0 + maxvshift/clight)/(1d0 - maxvshift/clight))
@@ -686,6 +741,7 @@
       Bl%nvmin = -nv
       Bl%nvmax = nv
       Bl%lam = Lines(i)%lam
+      ! this just determines the number of lines in the blend.
       do j = 1, nlines
         if ((j > i .and. (Lines(j)%lam/Lines(i)%lam) < maxmult) .or. &
             (j < i .and. (Lines(i)%lam/Lines(j)%lam) < maxmult) .or. j == i) then
@@ -695,6 +751,7 @@
       allocate (Bl%L(Bl%n))
       allocate (Bl%v(Bl%n))
       if (Bl%n > maxblend) maxblend = Bl%n
+      ! now actually assign the lines to the blend
       Bl%n = 0
       do j = 1, nlines
         if ((j > i .and. (Lines(j)%lam/Lines(i)%lam) < maxmult) .or. &
@@ -702,10 +759,10 @@
           Bl%n = Bl%n + 1
           Bl%L(Bl%n) = Lines(j)
           if (i == j) then
-            Bl%v(Bl%n) = 0d0
+            Bl%v(Bl%n) = 0d0 ! so the current line i, is the center of the blend
           else
             f = (Lines(j)%lam/Lines(i)%lam)**2
-            Bl%v(Bl%n) = clight*(f - 1d0)/(f + 1d0)
+            Bl%v(Bl%n) = clight*(f - 1d0)/(f + 1d0) ! this is the velocity fot line j on the vel grid of the current line i which sits a v=0
           end if
         end if
       end do
@@ -729,15 +786,16 @@
 
       allocate (Bl%next)
       Bl => Bl%next
-      nblends = nblends + 1 ! a bit strange, however, it is indeed the case that each line has its own Blend node
+      nblends = nblends + 1
     end do
 
-    call output("Number of lines: "//trim(int2string(nlines, '(i7)'))//"  Number of blends: "//trim(int2string(nblends, '(i7)')))  
+    call output("Number of lines: "//trim(int2string(nlines, '(i7)'))//"  Number of blends: "//trim(int2string(nblends, '(i7)')))
+    call clock_write(time, utime, "DetermineBlends: ")
 
     return
   end subroutine DetermineBlends
 
-subroutine InterpolateLam(lam0, ilam)
+  subroutine InterpolateLam(lam0, ilam)
     use GlobalSetup
     use Constants
     implicit none
@@ -777,11 +835,11 @@ subroutine InterpolateLam(lam0, ilam)
 
     return
   end subroutine InterpolateLam
-    
+
   subroutine map_pixels_to_path(igrid, npath)
     use GlobalSetup
     use Constants
-    use InOut    
+    use InOut
     implicit none
     integer, intent(in) :: igrid, npath
     real(kind=8) :: px(npath), py(npath), dist(npath), im_x, im_y
@@ -790,13 +848,13 @@ subroutine InterpolateLam(lam0, ilam)
     real(kind=8) :: time, utime
 
     integer :: i, j, ipath, iminpath, maxnpixpath
-    
-    call clock(time,utime)
+
+    !call clock(time, utime)
 
     ! If already allocated this was done already (same grid igrid is used again), no need to map things again
     if (allocated(P(igrid, 1)%im_ixy)) return
 
-    call output("Mapping pixels to path igrid,npath:"//trim(int2string(igrid, '(i7)'))//" "//trim(int2string(npath, '(i7)')))
+    !call output("Mapping pixels to path igrid,npath:"//trim(int2string(igrid, '(i7)'))//" "//trim(int2string(npath, '(i7)')))
 
     ! area of one pixel cm^2
     pixA = (im_coord(2) - im_coord(1))**2
@@ -874,7 +932,7 @@ subroutine InterpolateLam(lam0, ilam)
       !write (*, *) path2star%x, path2star%y, path2star%im_ixy(:, 1)
     end if
 
-    call clock_write(time, utime, "map_pixels_to_path:")
+    !call clock_write(time, utime, "map_pixels_to_path:")
     ! some log output and set the correction factor
 
     ! p0 => path2star
@@ -887,23 +945,30 @@ subroutine InterpolateLam(lam0, ilam)
 
   end subroutine map_pixels_to_path
 
-  subroutine AddImage(iv, flux0, p0, vmult, caller) 
-    ! properly adds the flux to the image cube, i.e. takes care of the pixel mapping and the mirroring if needed
+  subroutine AddImage(iv, lam_blend, flux0, p0, vmult, caller)
+    ! Maps velocity channel iv (relative to lam_blend) to the global linear
+    ! wavelength grid and accumulates flux into imcube.
     use GlobalSetup
     use Constants
     implicit none
-    real(kind=8), intent(in) :: flux0    
     integer, intent(in) :: iv
+    real(kind=8), intent(in) :: lam_blend
+    real(kind=8), intent(in) :: flux0
     integer, intent(in) :: vmult
     type(Path), intent(in) :: p0
     character(len=*), intent(in) :: caller        ! just for logging, can be removed
-    integer ix, iy, ipix
-    real(kind=8) :: fluxperpix, pixA
+    integer :: ix, iy, ipix, ivcube
+    real(kind=8) :: fluxperpix, lam_velo
 
-    !pixA = (im_coord(2) - im_coord(1))**2
+    ! compute absolute wavelength for this channel and map to global cube index
+    lam_velo = lam_blend*sqrt((1d0 + real(iv)*vresolution/clight)/ &
+                              (1d0 - real(iv)*vresolution/clight))
+    ivcube = nint((lam_velo - lam_cube(1))/dlam_cube) + 1
+    !write(*,*) caller," ", lam_blend,lam_velo,lmin,ivcube
+    if (ivcube < 1 .or. ivcube > nlam_cube) return
+
     ! simply distribute the flux for the path over all pixels equally
     fluxperpix = flux0/p0%im_npix
-    !fluxperpix=(flux0/p0%A)*pixA
 
     do ipix = 1, p0%im_npix
 
@@ -915,14 +980,7 @@ subroutine InterpolateLam(lam0, ilam)
         iy = npix - (iy - 1) ! for mirroring the whole thing
       end if
 
-      ! if (iv==1.or.iv==-1) then
-      !         write(*,*) "Caller: ",trim(caller)
-      !         write(*,*) "AddImage",iv,i,j,flux0,p0%x/AU,p0%y/AU,ix,iy
-      !         !write(*,*) delpix/AU,2.d0*Rout,delpix*real(npix)/AU
-      ! end if
-
-      imcube(iy, ix, iv) = imcube(iy, ix, iv) + fluxperpix ! P%y (Vertical) seems to be along the major axis - make it x
-      imcube_hit(iy, ix, iv) = imcube_hit(iy, ix, iv) + 1
+      imcube(iy, ix, ivcube) = imcube(iy, ix, ivcube) + fluxperpix ! P%y (Vertical) seems to be along the major axis - make it x
     end do
     return
   end subroutine AddImage

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -18,6 +18,7 @@
     logical :: gas, doit
     logical, allocatable :: doit_ib(:), doit_ib0(:)
     real(kind=8) :: flux1, flux2, flux3, fc, f, dnu, lam_w, lam_w_min, lam_w_max
+    real(kind=8) :: vlo_eff, vhi_eff
     real(kind=8) :: wl11, wl21, wl13, wl23, flux_l1, flux_l2, flux_c
     character(len=1000) :: comment
     character(len=500) :: imcubename
@@ -130,6 +131,7 @@
       LL = Bl%L(1)
       lam = Bl%lam
 
+      ! Only do the requested lines, lmin,lmax are set in the input file.
       if (lam > lmin .and. lam < lmax) then
         nl = nl + nb
 
@@ -180,7 +182,7 @@
         ! FIXME: check parallel implementation for imagecube
 !$OMP PARALLEL IF(.true.) &
 !$OMP DEFAULT(NONE) &
-!$OMP PRIVATE(j,PP,iv,vmult,ib0,nb0,gas,ib,imol,flux0,flux4,doit,flux_c,doit_ib,doit_ib0,lam_velo,callerstr) &
+!$OMP PRIVATE(j,PP,iv,vmult,ib0,nb0,gas,ib,imol,flux0,flux4,doit,flux_c,doit_ib,doit_ib0,lam_velo,callerstr,vlo_eff,vhi_eff) &
 !$OMP SHARED(i,P,ngrids,npoints,nb,LL,nv,Bl,vresolution,imol_blend,v_blend,flux,ilam) &
 !$OMP SHARED(iblends,flux2,maxblend,lam,lmin_next,imagecube,nvmin,nvmax)
         allocate (doit_ib0(maxblend))
@@ -220,45 +222,43 @@
                 if (nb > 1) then
                   ib0 = Bl%ib0(iv)
                   nb0 = Bl%nb0(iv)
-                  vmult = -1
-                  doit_ib(1:nb) = doit_ib0(1:nb)
-                  gas = .false.
-                  do ib = ib0, ib0 + nb0 - 1
-                    imol = Bl%L(ib)%imol
-                    if (((real(iv) - 0.5d0)*vresolution - Bl%v(ib)) < -PP%vmin(imol) &
-                        .and. ((real(iv) + 0.5d0)*vresolution - Bl%v(ib)) > -PP%vmax(imol)) then
-                      gas = .true.
-                      exit
+                  ! The disk is axisymmetric: each randomly-sampled path PP also represents its
+                  ! mirror-image on the opposite side of the disk, which has all line-of-sight
+                  ! velocities sign-flipped. We therefore trace the path twice -- once for each
+                  ! side -- each weighted by half the solid-angle area (PP%A/2).
+                  !   vmult = -1 : approaching (blueshifted) side, gas velocities in [-vmax, -vmin]
+                  !   vmult = +1 : receding  (redshifted)  side, gas velocities in [ vmin,  vmax]
+                  ! Thanks to Claude
+                  do vmult = -1, 1, 2
+                    doit_ib(1:nb) = doit_ib0(1:nb)
+                    gas = .false.
+                    do ib = ib0, ib0 + nb0 - 1
+                      imol = Bl%L(ib)%imol
+                      ! Check whether channel iv (corrected for blend velocity offset Bl%v(ib))
+                      ! overlaps the gas velocity range of this side. If not, skip line RT and
+                      ! fall back to the cached continuum flux.
+                      if (vmult == -1) then
+                        vlo_eff = -PP%vmax(imol)   ! approaching side: velocity range is [-vmax, -vmin]
+                        vhi_eff = -PP%vmin(imol)
+                      else
+                        vlo_eff = PP%vmin(imol)    ! receding side: velocity range is [vmin, vmax]
+                        vhi_eff = PP%vmax(imol)
+                      end if
+                      if (((real(iv) - 0.5d0)*vresolution - Bl%v(ib)) < vhi_eff &
+                          .and. ((real(iv) + 0.5d0)*vresolution - Bl%v(ib)) > vlo_eff) then
+                        gas = .true.
+                        exit
+                      end if
+                    end do
+                    if (gas) then
+                      call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
+                    else
+                      flux0 = flux_c
                     end if
+                    flux4(iv) = flux4(iv) + flux0*PP%A/2d0
+                    if (imagecube) call AddImage(iv, flux0*PP%A/2d0, PP, vmult, "call nb")
                   end do
-                  if (gas) then
-                    call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
-                  else
-                    flux0 = flux_c
-                  end if
-                  flux4(iv) = flux4(iv) + flux0*PP%A/2d0
-                  if (imagecube) call AddImage(iv, flux0*PP%A/2d0, PP, vmult, "call nb 1")
-                  vmult = 1
-                  doit_ib(1:nb) = doit_ib0(1:nb)
-                  gas = .false.
-                  do ib = ib0, ib0 + nb0 - 1
-                    imol = Bl%L(ib)%imol
-                    if (((real(iv) - 0.5d0)*vresolution - Bl%v(ib)) < PP%vmax(imol) &
-                        .and. ((real(iv) + 0.5d0)*vresolution - Bl%v(ib)) > PP%vmin(imol)) then
-                      gas = .true.
-                      exit
-                    end if
-                  end do
-                  if (gas) then
-                    call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
-                  else
-                    flux0 = flux_c
-                  end if
-                  flux4(iv) = flux4(iv) + flux0*PP%A/2d0
-                  ! FIXME: I think here  times vmult is required, but then it should also be in the line above ? or maybe not
-                  ! or maybe in that case vmult also needs to be ignored for the imagecube
-                  if (imagecube) call AddImage(iv, flux0*PP%A/2d0, PP, vmult, "call nb 2")
-
+                ! channel fully outside the line, so just add the continuum contribution 
                 else if (((real(iv) + 0.5d0)*vresolution > PP%vmax(LL%imol) .and. &
                           (real(iv) - 0.5d0)*vresolution > PP%vmax(LL%imol)) &
                          .or. ((real(iv) + 0.5d0)*vresolution < PP%vmin(LL%imol) .and. &
@@ -273,6 +273,7 @@
                       call AddImage(iv*vmult, flux0*PP%A/2d0, PP, vmult, callerstr)
                     end if
                   end do
+                ! channel covers single line (not blended)
                 else
                   doit_ib = .true.
                   call TraceFluxLines(PP, flux0, iv, vmult, imol_blend, v_blend, doit_ib, nb, 1)
@@ -306,8 +307,7 @@
 !$OMP FLUSH
 !$OMP END PARALLEL
         PP => path2star
-        ! FIXME: whatever is done here is not considered for the Images
-        ! I guess it is for the star ... need to check what are the coordinates, then one might just need to calls AddImage again
+        ! do the star 
         if (.not. allocated(PP%im_ixy)) allocate (PP%im_ixy(2, 1))
         do iv = Bl%nvmin, Bl%nvmax
           if (nb > 1) then  ! FIXME: this if seems to be unnecessary
@@ -413,7 +413,7 @@
           end do
           !write(*,*) iv,Bl%nvmax,nvmin,nvmax,lmin_next,lam_velo
           imcubename = "imcube"//trim(int2string(iblends, '(i0.10)'))//".fits"
-          write (*, *) "Writing image cube to file ", trim(imcubename)
+          call output("Writing image cube to file " // trim(imcubename))
           !write(*,*) imcube(12,60,-1),imcube(12,42,-1),imcube(12,60,1),imcube(12,42,1)
           ! currently this is per blend
           !call writefitsfile(imcubename,imcube*1e23/(distance*parsec)**2,nvmax-nvmin+1,npix)
@@ -781,18 +781,22 @@ subroutine InterpolateLam(lam0, ilam)
   subroutine map_pixels_to_path(igrid, npath)
     use GlobalSetup
     use Constants
+    use InOut    
     implicit none
     integer, intent(in) :: igrid, npath
     real(kind=8) :: px(npath), py(npath), dist(npath), im_x, im_y
     real(kind=8) :: maxx, maxr, maxrxp, maxrxm, pixA
     type(Path), pointer :: p0
+    real(kind=8) :: time, utime
 
     integer :: i, j, ipath, iminpath, maxnpixpath
     
+    call clock(time,utime)
+
     ! If already allocated this was done already (same grid igrid is used again), no need to map things again
     if (allocated(P(igrid, 1)%im_ixy)) return
 
-    write (*,*) "Mapping pixels to path igrid,npath", igrid, npath
+    call output("Mapping pixels to path igrid,npath:"//trim(int2string(igrid, '(i7)'))//" "//trim(int2string(npath, '(i7)')))
 
     ! area of one pixel cm^2
     pixA = (im_coord(2) - im_coord(1))**2
@@ -836,8 +840,8 @@ subroutine InterpolateLam(lam0, ilam)
         P(igrid, iminpath)%im_npix = P(igrid, iminpath)%im_npix + 1
 
         if (P(igrid, iminpath)%im_npix > maxnpixpath) then
-          write (*,*) 'Problem found to many pixels for path'
-          write (*,*) P(igrid, iminpath)%x/AU, P(igrid, iminpath)%y/AU, P(igrid, iminpath)%im_npix
+          call output('Problem found to many pixels for path')
+          call output(dbl2string(P(igrid, iminpath)%x/AU) // ' ' // dbl2string(P(igrid, iminpath)%y/AU) // ' ' // int2string(int(P(igrid, iminpath)%im_npix,kind=4), '(i7)'))
           stop
         end if
         P(igrid, iminpath)%im_ixy(1, P(igrid, iminpath)%im_npix) = i
@@ -870,19 +874,21 @@ subroutine InterpolateLam(lam0, ilam)
       !write (*, *) path2star%x, path2star%y, path2star%im_ixy(:, 1)
     end if
 
+    call clock_write(time, utime, "map_pixels_to_path:")
     ! some log output and set the correction factor
 
-    p0 => path2star
-    write (99, *) p0%x/AU, p0%y/AU, p0%A/AU/AU, p0%im_ixy(:, 1), p0%im_npix, p0%im_npix*pixA/AU/AU
+    ! p0 => path2star
+    ! write (99, *) p0%x/AU, p0%y/AU, p0%A/AU/AU, p0%im_ixy(:, 1), p0%im_npix, p0%im_npix*pixA/AU/AU
 
-    do ipath = 1, npath
-      p0 => P(igrid, ipath)
-      write (99, *) p0%x/AU, p0%y/AU, p0%A/AU/AU, p0%im_ixy(:, 1), p0%im_npix, p0%im_npix*pixA/AU/AU
-    end do
+    ! do ipath = 1, npath
+    !   p0 => P(igrid, ipath)
+    !   write (99, *) p0%x/AU, p0%y/AU, p0%A/AU/AU, p0%im_ixy(:, 1), p0%im_npix, p0%im_npix*pixA/AU/AU
+    ! end do
 
   end subroutine map_pixels_to_path
 
-  subroutine AddImage(iv, flux0, p0, vmult, caller) ! FIXME: don't need i, j anymore
+  subroutine AddImage(iv, flux0, p0, vmult, caller) 
+    ! properly adds the flux to the image cube, i.e. takes care of the pixel mapping and the mirroring if needed
     use GlobalSetup
     use Constants
     implicit none

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -88,6 +88,7 @@
       delpix = 2.d0*Rout*AU/real(npix)
       pixA = delpix**2
       starcorr = path2star%A/pixA
+      starcorr = 1.0
       write(*,*) "StarCorr: ",Rout,delpix/AU, starcorr
       !starcorr=1.0
       ! create the center coordinates for the pixels
@@ -464,7 +465,7 @@
         ! this adds the flux of the star from the last iv (nvmax), is strange, but does not matter, is removed afterwards anyway.
         flux2 = flux2 + flux0*PP%A
 
-        if (.true.) then
+        if (correct_continuum) then
           flux1 = 0d0
           flux3 = 0d0
 

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -778,98 +778,6 @@ subroutine InterpolateLam(lam0, ilam)
     return
   end subroutine InterpolateLam
     
-  subroutine DetermineBlendsOld(nv, maxblend, nvmin0, nvmax0)
-    use GlobalSetup
-    use Constants
-    integer ilines, ilines0, i, maxblend, nv, nvmax, iv, nvmin0, nvmax0
-    real(kind=8) maxvshift, maxmult, v
-    type(Blend), pointer :: Bl
-
-    maxvshift = 2d0*real(nv)*vresolution
-    maxmult = sqrt((1d0 + maxvshift/clight)/(1d0 - maxvshift/clight))
-
-    Bl => Blends
-
-    ilines = 2
-    ilines0 = 1
-    nblends = 0
-    maxblend = 0
-    nvmin0 = -nv
-    nvmax0 = 0
-    do while (ilines0 <= nlines)
-      Bl%n = 1
-      if (doblend) then
-        do while ((Lines(ilines)%lam/Lines(ilines - 1)%lam) < maxmult .and. ilines <= nlines)
-          Bl%n = Bl%n + 1
-          ilines = ilines + 1
-          if (ilines > nlines) exit
-        end do
-      end if
-      allocate (Bl%L(Bl%n))
-      allocate (Bl%v(Bl%n))
-      if (Bl%n > maxblend) maxblend = Bl%n
-      do i = 1, Bl%n
-        Bl%L(i) = Lines(ilines0 + i - 1)
-        if (i == 1) then
-          Bl%v(i) = 0d0
-        else
-          f = (Bl%L(i)%lam/Bl%L(1)%lam)**2
-          Bl%v(i) = clight*(f - 1d0)/(f + 1d0)
-        end if
-      end do
-      nvmax = nv + int(Bl%v(Bl%n)/vresolution)
-      if (nvmax > nvmax0) nvmax0 = nvmax
-      Bl%nvmin = -nv
-      Bl%nvmax = nvmax
-      allocate (Bl%ib0(-nv:nvmax))
-      allocate (Bl%nb0(-nv:nvmax))
-      do iv = -nv, nvmax
-        do i = 1, Bl%n
-          if (real(iv - nv)*vresolution <= Bl%v(i)) exit
-        end do
-        Bl%ib0(iv) = i
-        do i = Bl%n, 1, -1
-          if (real(iv + nv)*vresolution >= Bl%v(i)) exit
-        end do
-        Bl%nb0(iv) = i - Bl%ib0(iv) + 1
-      end do
-
-      v = -real(nv)*vresolution
-      Bl%lmin = Bl%L(1)%lam*sqrt((1d0 + v/clight)/(1d0 - v/clight))
-      v = real(nvmax)*vresolution
-      Bl%lmax = Bl%L(1)%lam*sqrt((1d0 + v/clight)/(1d0 - v/clight))
-
-      Bl%lam = Bl%L(1)%lam
-
-      ilines0 = ilines
-      ilines = ilines + 1
-      allocate (Bl%next)
-      Bl => Bl%next
-      nblends = nblends + 1
-    end do
-
-    return
-  end subroutine DetermineBlendsOld
-
-  ! ! create a regular pixel coordinate system in the image (fits) plane
-  ! ! with the center pixel being (0,0) x is the horizontal axis and y the vertical one
-  ! ! the x,y coordinates correspond to the center of the grid
-  ! subroutine Imcoords(npix,Rout,im_coord)
-  ! use GlobalSetup
-  ! use Constants
-  ! integer, intent(in) :: npix
-  ! real(kind=8), intent(in) :: Rout
-  ! real(kind=8), intent(inout) :: im_coord(npix,npix) ! should be already allocated
-  ! real(kind=8) :: delpix
-
-  ! delpix=2.d0*Rout*AU/real(npix)
-  ! ! create the coordinates for the pixels
-  ! do i=1,npix ! center coordinates of pixels in cm
-  !         im_coord(:,:)=delpix/2d0+delpix*(i-1)-Rout*AU
-  ! end do
-
-  ! end subroutine im_coords
-
   subroutine map_pixels_to_path(igrid, npath)
     use GlobalSetup
     use Constants
@@ -884,7 +792,7 @@ subroutine InterpolateLam(lam0, ilam)
     ! If already allocated this was done already (same grid igrid is used again), no need to map things again
     if (allocated(P(igrid, 1)%im_ixy)) return
 
-    write (*, *) "Mapping pixels to path igrid,npath", igrid, npath
+    write (*,*) "Mapping pixels to path igrid,npath", igrid, npath
 
     ! area of one pixel cm^2
     pixA = (im_coord(2) - im_coord(1))**2
@@ -928,8 +836,8 @@ subroutine InterpolateLam(lam0, ilam)
         P(igrid, iminpath)%im_npix = P(igrid, iminpath)%im_npix + 1
 
         if (P(igrid, iminpath)%im_npix > maxnpixpath) then
-          write (*, *) 'Problem found to many pixels for path'
-          write (*, *) P(igrid, iminpath)%x/AU, P(igrid, iminpath)%y/AU, P(igrid, iminpath)%im_npix
+          write (*,*) 'Problem found to many pixels for path'
+          write (*,*) P(igrid, iminpath)%x/AU, P(igrid, iminpath)%y/AU, P(igrid, iminpath)%im_npix
           stop
         end if
         P(igrid, iminpath)%im_ixy(1, P(igrid, iminpath)%im_npix) = i
@@ -959,7 +867,7 @@ subroutine InterpolateLam(lam0, ilam)
       path2star%im_npix = 1
       path2star%im_ixy(1, 1) = minloc(abs(im_coord - path2star%x), dim=1)
       path2star%im_ixy(2, 1) = minloc(abs(im_coord - path2star%y), dim=1)
-      write (*, *) path2star%x, path2star%y, path2star%im_ixy(:, 1)
+      !write (*, *) path2star%x, path2star%y, path2star%im_ixy(:, 1)
     end if
 
     ! some log output and set the correction factor

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -57,20 +57,20 @@
       allocate (imcube(npix, npix, nvmin:nvmax))
       allocate (imcube_hit(npix, npix, nvmin:nvmax))
       allocate (im_coord(npix))
+      write(*,*) "Rout",Rout
       delpix = 2.d0*Rout*AU/real(npix)
       ! create the center coordinates for the pixels
       do i = 1, npix ! center coordinates of pixels in cm
         im_coord(i) = delpix/2d0 + delpix*(i - 1) - Rout*AU
       end do
-      !write(*,*) im_coord/AU
-
     end if
-
+    
     lam = lmin
     ilam1 = 1
     do while (lam > lam_cont(ilam1 + 1) .and. ilam1 < nlam)
       ilam1 = ilam1 + 1
     end do
+
     allocate (profile(-nvprofile:nvprofile))
     allocate (profile_nz(-nvprofile:nvprofile))
     do i = 0, nR
@@ -115,7 +115,7 @@
     Bl => Blends
     do iblends = 1, nblends
       if (imagecube) then
-        imcube = 0d0 ! FIXME: in the end I want only one cube, not for each blend, I think that shoulbe be moved outside of the blends loop (like flux)
+        imcube = 0d0 ! FIXME: in the end I want only one cube, not for each blend, I think that should be moved outside of the blends loop (like flux)
         imcube_hit = 0
       end if
       flux = 0d0
@@ -141,7 +141,7 @@
           if (ilam == nlam) exit
         end do
 
-        ! CHR: What is this doing ?
+        ! that writes out continuum only points for the spectrum.
         if (ilam > ilam1) then
           do k = ilam1 + 1, ilam
             if (lam_cont(k) > lcmin .and. lam_cont(k) < Bl%lmin) then
@@ -900,7 +900,7 @@ subroutine InterpolateLam(lam0, ilam)
     integer ix, iy, ipix
     real(kind=8) :: fluxperpix, pixA
 
-    pixA = (im_coord(2) - im_coord(1))**2
+    !pixA = (im_coord(2) - im_coord(1))**2
     ! simply distribute the flux for the path over all pixels equally
     fluxperpix = flux0/p0%im_npix
     !fluxperpix=(flux0/p0%A)*pixA

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -24,8 +24,10 @@
     real(kind=8) :: wl11, wl21, wl13, wl23, flux_l1, flux_l2, flux_c
     character(len=1000) :: comment
     character(len=200) :: callerstr
-    real(kind=8) :: delpix, starcorr, lamgapmax,lamgapmin
+    real(kind=8) :: starcorr, lamgapmax,lamgapmin
     real(kind=8) :: time, utime, timegap, utimegap
+    integer :: status
+    real(kind=8) :: size_imcube
 
     call output("==================================================================")
     call output("Preparing the profiles")
@@ -59,17 +61,28 @@
     if (imagecube) then
       call clock(time, utime)
       call output("")
-      call output("Preparing the image cube ...")
-      call output("Allocating the image cube ...")
+      call output("==================================================================")
+      call output("Preparing the image cube ...")      
 
-      ! FIXME: vresolution does not give a constand dlam_cube, but for now we want that
+      ! FIXME: vresolution does not give a constant dlam_cube, but for now we want that
       ! However, to avoid that a wl bin of the cube is skipped because of a coarser wl resolution of a blend
       ! use dlam corresponding to lmax
-
       !dlam_cube = 0.5d0*(lmin + lmax)*vresolution/clight
       dlam_cube=lamvelo(lmax,1)-lmax
       nlam_cube = int((lmax - lmin)/dlam_cube) ! number of center wl-points
-      allocate (imcube(npix, npix, nlam_cube))
+      call output("Image cube wl grid: "//trim(dbl2string(lmin, '(F10.5)'))//" - "// &
+                   trim(dbl2string(lmax, '(F10.5)'))//" micron, dlam: "// &
+                   trim(dbl2string(dlam_cube, '(1pE15.7)'))//" micron, nlam_cube: "// &
+                   trim(int2string(nlam_cube, '(i7)')))
+      
+      size_imcube = real(npix)*real(npix)*real(nlam_cube)*sizeof(real(4))/1.e9  ! size in bytes, 4 bytes per real(4)
+      call output("Allocating the image cube with size: "//trim(dbl2string(size_imcube, '(F11.4)'))//" GB")
+
+      allocate (imcube(npix, npix, nlam_cube),stat=status)
+      if (status /= 0) then
+        call output("Error allocating imcube! Reducing npix, increasing vresolution or shrinking lmin to lmax, might help.")
+        stop
+      end if
       allocate (lam_cube(nlam_cube))
       allocate (lamb_cube(nlam_cube + 1))
       ! for convenience store the center wl points
@@ -87,9 +100,10 @@
       ! Rout is currently the max radius of the path grid. 
       delpix = 2.d0*Rout*AU/real(npix)
       pixA = delpix**2
-      starcorr = path2star%A/pixA
+      ! FIXM: is not really doing what I want
+      !starcorr = path2star%A/pixA
       starcorr = 1.0
-      write(*,*) "StarCorr: ",Rout,delpix/AU, starcorr
+      !write(*,*) "StarCorr: ",Rout,delpix/AU, starcorr
       !starcorr=1.0
       ! create the center coordinates for the pixels
       call output("Calculate pixel coordinates ...")
@@ -98,8 +112,9 @@
       end do
 
       ! map the paths to the pixel, need to do it for each grid
+      ! FIXME: hardcoded first grid
       !do i = 1, ngrids
-      call output("map grid "//int2string(1, '(i7)')//" to pixels")
+      call output("map path grid "//int2string(1, '(i3)')//" to pixel grid ...")
       call map_pixels_to_path(1, npoints(1))
       !end do
 
@@ -113,7 +128,7 @@
       path2star%imcube_cont_flux = -1.0
 
       call output("Image cube has "//trim(int2string(nlam_cube, '(i7)'))//" channels (dlam="//trim(dbl2string(dlam_cube, '(1pE15.7)'))//") and "//trim(int2string(npix*npix, '(i7)'))//" pixels.")
-      call output("Image cube size: "//trim(dbl2string(sizeof(imcube)/1.e9, '(F11.4)'))//" GB")
+      call output("Allocated image cube size: "//trim(dbl2string(sizeof(imcube)/1.e9, '(F11.4)'))//" GB")
       call clock_write(time, utime, "Prepare image cube: ")
 
     end if
@@ -205,7 +220,7 @@
           !write(*,*) "lamgap: ",lamgapmax,lmin_next,lcmin,Bl%lmin,Bl%lmax,lamb_cube(i+1),ilam_cube_start,ilam_cube_end,lam_cube(ilam_cube_start),lam_cube(ilam_cube_end)
           ! I have some gap
           if (ilam_cube_start <= ilam_cube_end) then
-            call output("  Fill imcube gap from lam "//dbl2string(lam_cube(ilam_cube_start))//" to"//dbl2string(lam_cube(ilam_cube_end))//" with continuum.")          
+            
             !write(*,*) Bl%lmin, Bl%lmax,lamgapmax, lcmin, lamb_cube(ilam_cube_start),lam_cube(ilam_cube_start),lam_cube(ilam_cube_end)
             do i = ilam_cube_start, ilam_cube_end
               !if ((lam_cube(i) > lcmin .and. lam_cube(i) < Bl%lmin) .or. &
@@ -235,7 +250,9 @@
               call AddImage(lam_cube(i), flux0*PP%A*starcorr, flux0*PP%A*starcorr, PP, 1, "star0")
               !end if
             end do
-            call clock_write(timegap, utimegap, "  Fill imcube gap: ")
+            call clock_write(timegap, utimegap, "  Fill imcube gap: ("// &
+                             dbl2string(lam_cube(ilam_cube_start),'(F10.5)')//" -"// &
+                             dbl2string(lam_cube(ilam_cube_end),'(F10.5)')//" micron)")
           end if
         end if
 
@@ -943,7 +960,7 @@
     implicit none
     integer, intent(in) :: igrid, npath
     real(kind=8) :: px(npath), py(npath), dist(npath), im_x, im_y
-    real(kind=8) :: maxx, maxr, maxrxp, maxrxm !pixA
+    real(kind=8) :: maxr
     type(Path), pointer :: p0
     real(kind=8) :: time, utime
 
@@ -1003,8 +1020,8 @@
           call output(dbl2string(P(igrid, iminpath)%x/AU) // ' ' // dbl2string(P(igrid, iminpath)%y/AU) // ' ' // int2string(int(P(igrid, iminpath)%im_npix,kind=4), '(i7)'))
           stop
         end if
-        P(igrid, iminpath)%im_ixy(1, P(igrid, iminpath)%im_npix) = i
-        P(igrid, iminpath)%im_ixy(2, P(igrid, iminpath)%im_npix) = j
+        P(igrid, iminpath)%im_ixy(1, P(igrid, iminpath)%im_npix) = int(i,kind=2) 
+        P(igrid, iminpath)%im_ixy(2, P(igrid, iminpath)%im_npix) = int(j,kind=2)
       end do
     end do
 
@@ -1017,8 +1034,8 @@
       if (p0%im_npix > 0) cycle
       ! find the closest pixel
       p0%im_npix = 1
-      p0%im_ixy(1, 1) = minloc(abs(im_coord - p0%x), dim=1)
-      p0%im_ixy(2, 1) = minloc(abs(im_coord - p0%y), dim=1)
+      p0%im_ixy(1, 1) = int(minloc(abs(im_coord - p0%x), dim=1),kind=2)
+      p0%im_ixy(2, 1) = int(minloc(abs(im_coord - p0%y), dim=1),kind=2)
     end do
 
     ! special treatment for the star
@@ -1028,8 +1045,8 @@
       allocate (path2star%im_ixy(2, 1))
 
       path2star%im_npix = 1
-      path2star%im_ixy(1, 1) = minloc(abs(im_coord - path2star%x), dim=1)
-      path2star%im_ixy(2, 1) = minloc(abs(im_coord - path2star%y), dim=1)
+      path2star%im_ixy(1, 1) = int(minloc(abs(im_coord - path2star%x), dim=1),kind=2)
+      path2star%im_ixy(2, 1) = int(minloc(abs(im_coord - path2star%y), dim=1),kind=2)
       !write (*, *) path2star%x, path2star%y, path2star%im_ixy(:, 1)
     end if
 
@@ -1079,14 +1096,13 @@
 
     ivc = ivcube(lam_velo)
     ivmult_idx = (vmult + 3)/2 ! for symmetry treatment
-    ! FIXME: remove Sanity check, should reall not happen
-    if (lam_velo < lamb_cube(ivc) .or. lam_velo > lamb_cube(ivc + 1)) then
-      write (*, *) ivc, lam_velo, lamb_cube(ivc), lam_cube(ivc), lamb_cube(ivc + 1)
-      call output("Warning: lam_velo="//trim(dbl2string(lam_velo, '(f15.8)'))// &
-                  " is outside of the cube limits. Skipping this channel for the image cube. Caller: "//trim(caller))
-      stop
-    end if
-    !write(*,*) caller," ", lam_blend,lam_velo,lmin,ivcube
+    ! FIXME: remove Sanity check, should really not happen
+    ! if (lam_velo < lamb_cube(ivc) .or. lam_velo > lamb_cube(ivc + 1)) then
+    !   write (*, *) ivc, lam_velo, lamb_cube(ivc), lam_cube(ivc), lamb_cube(ivc + 1)
+    !   call output("Warning: lam_velo="//trim(dbl2string(lam_velo, '(f15.8)'))// &
+    !               " is outside of the cube limits. Skipping this channel for the image cube. Caller: "//trim(caller))
+    !   stop
+    ! end if    
 
     ! FIXME: Assume that continuum can never be < 0
     ! if continuum is still < 0, we add the continuum the first time.
@@ -1098,27 +1114,8 @@
       fluxadd = flux0
     end if
     p0%imcube_cont_flux(ivc, ivmult_idx) = fluxcont
-    ! if (ivc == 873.or.ivc == 875) then
-    !   write(*,*) "AddImage1: ", ivc,trim(caller), lam_velo, lam_cube(ivc), flux0, fluxcont, fluxadd
-    ! end if
-    ! if (ivc == 874) then
-    !   write(*,*) "AddImage2: ", trim(caller), lam_velo, lam_cube(ivc), vmult, flux0, fluxcont, fluxadd
-    ! end if
-
-    ! Guard continuum-only contributions: each (cube_bin, vmult-side) must be filled at most once
-    ! per path to prevent double-counting when multiple blend channels map to the same bin.
-    ! ivmult_idx: 1 = vmult=-1, 2 = vmult=+1
-
-    ! if (is_cont) then
-    !   ivmult_idx = (vmult + 3) / 2
-    !   if (ivc==11) then
-    !      write(*,*) "Check cont guard: ", trim(caller), lam_velo, ivc, vmult, p0%im_npix, p0%im_ixy(:, 1:p0%im_npix),p0%imcube_cont_done(ivc, ivmult_idx)
-    !   end if
-    !   if (p0%imcube_cont_done(ivc, ivmult_idx)) return
-    !   p0%imcube_cont_done(ivc, ivmult_idx) = .true.
-    ! end if
-
-    fluxperpix = fluxadd/p0%im_npix
+   
+    fluxperpix = fluxadd/real(p0%im_npix, kind=8)
 
     do ipix = 1, p0%im_npix
 
@@ -1130,14 +1127,10 @@
         iy = npix - (iy - 1) ! for mirroring the whole thing
       end if
 
-      ! needs atomic as different paths can contribute to the same pixels
+      ! needs atomic as different paths can contribute to the same pixels, and we parallelize over paths.
   !$OMP ATOMIC
-      imcube(iy, ix, ivc) = imcube(iy, ix, ivc) + fluxperpix ! P%y (Vertical) seems to be along the major axis - make it x
+      imcube(iy, ix, ivc) = imcube(iy, ix, ivc) + real(fluxperpix,kind=4) ! P%y (Vertical) seems to be along the major axis - make it x
     end do
-
-    ! if (ivc==11) then
-    !    write(*,*) lamb_cube(11),lam_cube(11),lamb_cube(11+1),"caller: ", trim(caller), " lam_velo: ", lam_velo, " ivc: ", ivc, vmult,p0%im_npix,fluxperpix,p0%x,p0%y,ix,iy
-    ! end if
 
     return
   end subroutine AddImage

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -3,7 +3,7 @@
     use Constants
     use InOut
     implicit none
-    integer :: i, j, ilam, k, iblends, vmult, iv, nv, nl, imol, maxblend, ilines, nvmax, nvmin
+    integer :: i, j,igrid, ilam, k, iblends, vmult, iv, nv, nl, imol, maxblend, ilines, nvmax, nvmin
     integer :: nb, ib0, nb0, ib, nltot
     integer(kind=4) :: counts, count_rate, count_max
     integer, external :: OMP_GET_THREAD_NUM
@@ -25,7 +25,7 @@
     character(len=500) :: imcubename
     character(len=40) :: callerstr
     real(kind=8) :: imcube_size
-    real(kind=8) :: delpix
+    real(kind=8) :: delpix,starcorr    
     real(kind=8) :: time, utime, timegap, utimegap
 
     call output("==================================================================")
@@ -73,6 +73,8 @@
       imcube = 0d0      
       allocate (im_coord(npix))
       delpix = 2.d0*Rout*AU/real(npix)
+      pixA=delpix**2
+      starcorr=path2star%A/pixA
       ! create the center coordinates for the pixels
       do i = 1, npix ! center coordinates of pixels in cm
         im_coord(i) = delpix/2d0 + delpix*(i - 1) - Rout*AU
@@ -154,7 +156,7 @@
       if (lam > lmin .and. lam < lmax) then
         nl = nl + nb
 
-        ! make sure that we do not end up with empy channels.
+        ! make sure that we do not end up with empty channels.
         if (imagecube) then
           ilam_cube_start = nlam_cube
           ilam_cube_end = 0
@@ -178,22 +180,27 @@
                   ilam_cube_gap = ilam_cube_gap + 1
                 end do
                 call InterpolateLam(lam_cube(i), ilam_cube_gap)
+                do igrid = 1,ngrids
 !$OMP PARALLEL DEFAULT(NONE) &
-!$OMP PRIVATE(j, PP, flux0) &
-!$OMP SHARED(P, npoints, lam_cube, i)
+!$OMP PRIVATE(j,PP, flux0,vmult) &
+!$OMP SHARED(P, npoints, lam_cube, i, igrid, ngrids)
 !$OMP DO SCHEDULE(dynamic,1)
-                do j = 1, npoints(1)  ! just do it for the first grid
-                  PP => P(1, j)
-                  call ContContrPath(PP, flux0)
-                  call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, 1, "continuum in gap")
-                  ! because of symmetry
-                  call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, -1, "continuum in gap")
-                end do
+                  do j = 1, npoints(igrid)  ! just do it for the first grid
+                    PP => P(igrid, j)
+                    call ContContrPath(PP, flux0)
+                    flux0=flux0/real(ngrids)
+                    do vmult=-1,1,2
+                      call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, vmult, "continuum in gap")                  
+                    end do
+                  end do
 !$OMP END DO
 !$OMP END PARALLEL
-                PP => path2star
-                call ContContrPath(PP, flux0)
-                call AddImage(0, lam_cube(i), flux0*PP%A, PP, 1, "star in gap")
+                enddo
+                ! do the star, as there are no lines, nb = 0
+                PP => path2star                
+                call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, 0)    
+                ! for the star we correct the area as the pixel is usuall much larger than the star            
+                call AddImage(0, lam_cube(i), flux0*PP%A*starcorr, PP, 1, "trace star")
               end if
             end do
             call clock_write(timegap, utimegap,"  Fill imcube gap: ")
@@ -210,7 +217,7 @@
           ilam = ilam + 1
           if (ilam == nlamCont) exit
         end do
-        ! that writes out continuum only points for the spectrum, however, onlz the points available
+        ! that writes out continuum only points for the spectrum, however, only the points available
         ! which could be only 1
         if (ilam > ilam1Cont) then
           do k = ilam1Cont + 1, ilam
@@ -359,11 +366,14 @@
               end if
             end do
           else
+            !write(*,*) "call not dotit"
             flux0 = flux_c
             flux4(Bl%nvmin:Bl%nvmax) = flux4(Bl%nvmin:Bl%nvmax) + flux0*PP%A
             if (imagecube) then
               do iv = Bl%nvmin, Bl%nvmax
-                call AddImage(iv, lam, flux0*PP%A, PP, 1, "call not doit")
+                do vmult = -1,1,2
+                  call AddImage(iv, lam, flux0*PP%A, PP, vmult, "call not doit")
+                enddo
               end do
             end if
           end if
@@ -388,7 +398,7 @@
             call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
             flux(iv) = flux(iv) + flux0*PP%A
           end if
-          if (imagecube) call AddImage(iv, lam, flux0*PP%A, PP, 1, "trace star")
+          if (imagecube) call AddImage(iv, lam, flux0*PP%A*starcorr, PP, 1, "trace star")
         end do
         flux2 = flux2 + flux0*PP%A
 
@@ -525,7 +535,7 @@
     return
   end subroutine RaytraceLines
 
-  subroutine ContContrPath(p0, flux)!
+  subroutine ContContrPath(p0, flux)
 !   Compute the continuum flux along path p0 at the current line-center
 !   wavelength (set by the last call to InterpolateLam). Integrates the
 !   formal RT solution cell by cell using the pre-interpolated dust opacity
@@ -843,7 +853,7 @@
     implicit none
     integer, intent(in) :: igrid, npath
     real(kind=8) :: px(npath), py(npath), dist(npath), im_x, im_y
-    real(kind=8) :: maxx, maxr, maxrxp, maxrxm, pixA
+    real(kind=8) :: maxx, maxr, maxrxp, maxrxm !pixA
     type(Path), pointer :: p0
     real(kind=8) :: time, utime
 
@@ -857,7 +867,7 @@
     !call output("Mapping pixels to path igrid,npath:"//trim(int2string(igrid, '(i7)'))//" "//trim(int2string(npath, '(i7)')))
 
     ! area of one pixel cm^2
-    pixA = (im_coord(2) - im_coord(1))**2
+    !pixA = (im_coord(2) - im_coord(1))**2
 
     ! the paths do not sample the whole image (just the disk)
     ! In theory this could be different (e.g. if not a disk)
@@ -883,8 +893,8 @@
       ! only care about the positive half
       do j = int(npix/2 + 1), npix
         im_y = im_coord(j)
-        ! the Path grid does not cover a circel (due to inclination)
-        ! along the x is the minor axis, which has differen Rmax depending on sign
+        ! the Path grid does not cover a circle (due to inclination)
+        ! along the x is the minor axis, which has different Rmax depending on sign
         if (sqrt((im_x)**2 + (im_y)**2) > maxr) cycle
         !if ((im_x<0).and.im_x<maxrxm) cycle FIXME: doesn't really work
         !if ((im_x>0).and.im_x>maxrxp) cycle
@@ -958,7 +968,7 @@
     type(Path), intent(in) :: p0
     character(len=*), intent(in) :: caller        ! just for logging, can be removed
     integer :: ix, iy, ipix, ivcube
-    real(kind=8) :: fluxperpix, lam_velo
+    real(kind=8) :: fluxperpix, lam_velo,singlepixcorr
 
     ! compute absolute wavelength for this channel and map to global cube index
     lam_velo = lam_blend*sqrt((1d0 + real(iv)*vresolution/clight)/ &
@@ -967,8 +977,7 @@
     !write(*,*) caller," ", lam_blend,lam_velo,lmin,ivcube
     if (ivcube < 1 .or. ivcube > nlam_cube) return
 
-    ! simply distribute the flux for the path over all pixels equally
-    fluxperpix = flux0/p0%im_npix
+    fluxperpix = flux0/p0%im_npix    
 
     do ipix = 1, p0%im_npix
 

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -97,6 +97,15 @@
       call map_pixels_to_path(1, npoints(1))
       !end do
 
+      ! Allocate per-path, per-(cube-bin, vmult-side) continuum-done flags.
+      ! Dim2: 1 = vmult=-1 side, 2 = vmult=+1 side.
+      do j = 1, npoints(1)
+        allocate(P(1,j)%imcube_cont_done(nlam_cube, 2))
+        P(1,j)%imcube_cont_done = .false.
+      end do
+      allocate(path2star%imcube_cont_done(nlam_cube, 2))
+      path2star%imcube_cont_done = .false.
+
       call output("Image cube has "//trim(int2string(nlam_cube, '(i7)'))//" channels (dlam="//trim(dbl2string(dlam_cube, '(F11.4)'))//") and "//trim(int2string(npix*npix, '(i7)'))//" pixels.")
       call output("Image cube size: "//trim(dbl2string(sizeof(imcube)/1.e9, '(F11.4)'))//" GB")
       call clock_write(time, utime, "Prepare image cube: ")
@@ -205,7 +214,7 @@
                   PP => P(1, j)
                   call ContContrPath(PP, flux0)
                   do vmult=-1,1,2
-                    call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, vmult, "continuum in gap")                  
+                    call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, vmult, "continuum in gap", .true.)                  
                   end do
                 end do
 !$OMP END DO
@@ -214,7 +223,7 @@
                 PP => path2star                
                 call Trace2StarLines(PP, flux0, 0, imol_blend, v_blend, 0)    
                 ! for the star we correct the area as the pixel is usually much larger than the star            
-                call AddImage(0, lam_cube(i), flux0*PP%A*starcorr, PP, 1, "trace star gap")
+                call AddImage(0, lam_cube(i), flux0*PP%A*starcorr, PP, 1, "trace star gap", .true.)
               !end if
             end do
             call clock_write(timegap, utimegap,"  Fill imcube gap: ")
@@ -352,13 +361,13 @@
                     end do
                     if (gas) then
                       call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
-                      if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, callerstr)
+                      if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, callerstr, .false.)
                     else
                       flux0 = flux_c
                       !write (callerstr, "(A,' ' ,i5,A,F10.3,A,F10.3)") "call nb ", iblends,"lmin:",lmin_next,"lv:",lam_velo
-                      ! FIXME: It cann happen hat somehoe a iv of several blends produces a continuum in the same imcube channel
-                      ! hence the continuum is contouned multipe times, the reason is the if (gas) thingy  
-                      if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, "cont")
+                      ! Fixed: imcube_cont_done flag in AddImage prevents double-counting when multiple
+                      ! blend channels map to the same cube bin with no gas.
+                      if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, "cont", .true.)
                     end if
                     flux4(iv) = flux4(iv) + flux0*PP%A/2d0
                     !write (callerstr, "(A,' ' ,i5,A,F10.3,A,F10.3)") "call nb ", iblends,"lmin:",lmin_next,"lv:",lam_velo
@@ -376,7 +385,7 @@
                     ! FIXME: callerstring is only for debugging, remove it
                     write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else if", iv, vmult
                     if (imagecube) then
-                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, "cont")
+                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, "cont", .true.)
                     end if
                   end do
                   ! channel covers single line (not blended)
@@ -387,7 +396,7 @@
                     flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0
                     write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else", iv, vmult
                     if (imagecube) then
-                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, callerstr)
+                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, callerstr, .false.)
                     end if
                   end do
                 end if
@@ -403,7 +412,7 @@
                 do iv = Bl%nvmin, Bl%nvmax
                   lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
                   if (lam_velo > lmin_next) then
-                    call AddImage(iv, lam, flux0*PP%A, PP, vmult, "call not doit")
+                    call AddImage(iv, lam, flux0*PP%A, PP, vmult, "call not doit", .true.)
                   endif
                 end do
               end do 
@@ -430,7 +439,7 @@
             call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
             flux(iv) = flux(iv) + flux0*PP%A
           end if
-          if (imagecube) call AddImage(iv, lam, flux0*PP%A*starcorr, PP, 1, "trace star")
+          if (imagecube) call AddImage(iv, lam, flux0*PP%A*starcorr, PP, 1, "trace star", .false.)
         end do
         flux2 = flux2 + flux0*PP%A
 
@@ -992,9 +1001,12 @@
 
   end subroutine map_pixels_to_path
 
-  subroutine AddImage(iv, lam_blend, flux0, p0, vmult, caller)
+  subroutine AddImage(iv, lam_blend, flux0, p0, vmult, caller, is_cont)
     ! Maps velocity channel iv (relative to lam_blend) to the global linear
     ! wavelength grid and accumulates flux into imcube.
+    ! is_cont=.true. marks a pure-continuum contribution: the call is skipped if this
+    ! (cube_bin, vmult-side) has already been filled for this path, preventing double-counting
+    ! when multiple blend channels map to the same cube bin.
     use GlobalSetup
     use Constants
     use InOut
@@ -1003,9 +1015,10 @@
     real(kind=8), intent(in) :: lam_blend
     real(kind=8), intent(in) :: flux0
     integer, intent(in) :: vmult
-    type(Path), intent(in) :: p0
+    type(Path), intent(inout) :: p0
     character(len=*), intent(in) :: caller        ! just for logging, can be removed
-    integer :: ix, iy, ipix, ivcube
+    logical, intent(in) :: is_cont
+    integer :: ix, iy, ipix, ivcube, ivmult_idx
     real(kind=8) :: fluxperpix, lam_velo
 
     ! the cube goes strictly from lmin (channel centers) to lmax, but parts of a bleand can be outside    
@@ -1030,7 +1043,15 @@
     ! some parts of the line can be outside of the cube limits, we ignore those.
     if (ivcube < 1 .or. ivcube > nlam_cube) return
 
-    
+    ! Guard continuum-only contributions: each (cube_bin, vmult-side) must be filled at most once
+    ! per path to prevent double-counting when multiple blend channels map to the same bin.
+    ! ivmult_idx: 1 = vmult=-1, 2 = vmult=+1
+    ivmult_idx = (vmult + 3) / 2
+    if (is_cont) then
+      if (p0%imcube_cont_done(ivcube, ivmult_idx)) return
+      p0%imcube_cont_done(ivcube, ivmult_idx) = .true.
+    end if
+
     fluxperpix = flux0/p0%im_npix    
 
     do ipix = 1, p0%im_npix

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -60,8 +60,7 @@
       call output("")
       call output("Preparing the image cube ...")
       call output("Allocating the image cube ...")
-      dlam_cube = 0.5d0*(lmin + lmax)*vresolution/clight
-      write(*,*) "dlam_cube: ", dlam_cube
+      dlam_cube = 0.5d0*(lmin + lmax)*vresolution/clight      
       nlam_cube = int((lmax - lmin)/dlam_cube) ! number of center wl-points
       allocate (imcube(npix, npix, nlam_cube))      
       allocate (lam_cube(nlam_cube))
@@ -76,9 +75,6 @@
       do i = 1, nlam_cube+1
         lamb_cube(i) = (lmin - dlam_cube/2d0) + dlam_cube*(i-1)
       end do
-      write(*,*) lam_cube
-      write(*,*) lamb_cube
-
 
       imcube = 0d0      
       allocate (im_coord(npix))

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -587,7 +587,7 @@
     if (imagecube) then
       call output("")
       call output("Writing image cube to file imcube.fits ...")
-      call writefitsfile(trim(imagecube_filename), imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin, lmin, .true.)
+      call write_imcube(trim(imagecube_filename), .true.)
       call output("")
     end if
 

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -75,7 +75,7 @@
                    trim(dbl2string(dlam_cube, '(1pE15.7)'))//" micron, nlam_cube: "// &
                    trim(int2string(nlam_cube, '(i7)')))
       
-      size_imcube = real(npix)*real(npix)*real(nlam_cube)*sizeof(real(4))/1.e9  ! size in bytes, 4 bytes per real(4)
+      size_imcube = real(npix)*real(npix)*real(nlam_cube)*sizeof(real(1.0,kind=4))/1.e9  ! size in bytes, 4 bytes per real(4)
       call output("Allocating the image cube with size: "//trim(dbl2string(size_imcube, '(F11.4)'))//" GB")
 
       allocate (imcube(npix, npix, nlam_cube),stat=status)

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -3,7 +3,7 @@
     use Constants
     use InOut
     implicit none
-    integer :: i, j,igrid, ilam, k, iblends, vmult, iv, nv, nl, imol, maxblend, ilines, nvmax, nvmin
+    integer :: i, j, igrid, ilam, k, iblends, vmult, iv, nv, nl, imol, maxblend, ilines, nvmax, nvmin
     integer :: nb, ib0, nb0, ib, nltot
     integer(kind=4) :: counts, count_rate, count_max
     integer, external :: OMP_GET_THREAD_NUM
@@ -11,7 +11,8 @@
     integer :: ilam_cube_gap, ilam_cube_start, ilam_cube_end
     real(kind=8), allocatable :: v_blend(:), flux4(:)
     real(kind=8) :: lam, flux0, starttime, stoptime, fact, lcmin
-    real(kind=8) :: lmin_next, lam_velo
+    real(kind=8) :: lmin_next, lam_velo,lam_interpolate
+    real(kind=8) ::lamvelo
     real(kind=8), allocatable :: flux(:), flux_cont(:)
     type(Path), pointer :: PP
     type(Line) :: LL
@@ -23,8 +24,8 @@
     real(kind=8) :: wl11, wl21, wl13, wl23, flux_l1, flux_l2, flux_c
     character(len=1000) :: comment
     character(len=200) :: callerstr
-    real(kind=8) :: delpix,starcorr,lamgapmax    
-    real(kind=8) :: time, utime, timegap, utimegap    
+    real(kind=8) :: delpix, starcorr, lamgapmax,lamgapmin
+    real(kind=8) :: time, utime, timegap, utimegap
 
     call output("==================================================================")
     call output("Preparing the profiles")
@@ -60,33 +61,41 @@
       call output("")
       call output("Preparing the image cube ...")
       call output("Allocating the image cube ...")
-      dlam_cube = 0.5d0*(lmin + lmax)*vresolution/clight      
+
+      ! FIXME: vresolution does not give a constand dlam_cube, but for now we want that
+      ! However, to avoid that a wl bin of the cube is skipped because of a coarser wl resolution of a blend
+      ! use dlam corresponding to lmax
+
+      !dlam_cube = 0.5d0*(lmin + lmax)*vresolution/clight
+      dlam_cube=lamvelo(lmax,1)-lmax
       nlam_cube = int((lmax - lmin)/dlam_cube) ! number of center wl-points
-      allocate (imcube(npix, npix, nlam_cube))      
+      allocate (imcube(npix, npix, nlam_cube))
       allocate (lam_cube(nlam_cube))
-      allocate (lamb_cube(nlam_cube+1))
+      allocate (lamb_cube(nlam_cube + 1))
       ! for convenience store the center wl points
       ! lmin should be the first center
       do i = 1, nlam_cube
         lam_cube(i) = lmin + dlam_cube*(i - 1)
       end do
-
-      ! store the edge wl points      
-      do i = 1, nlam_cube+1
-        lamb_cube(i) = (lmin - dlam_cube/2d0) + dlam_cube*(i-1)
+      ! store the edge wl points
+      do i = 1, nlam_cube + 1
+        lamb_cube(i) = (lmin - dlam_cube/2d0) + dlam_cube*(i - 1)
       end do
 
-      imcube = 0d0      
+      imcube = 0d0
       allocate (im_coord(npix))
+      ! Rout is currently the max radius of the path grid. 
       delpix = 2.d0*Rout*AU/real(npix)
-      pixA=delpix**2
-      starcorr=path2star%A/pixA
+      pixA = delpix**2
+      starcorr = path2star%A/pixA
+      write(*,*) "StarCorr: ",Rout,delpix/AU, starcorr
+      !starcorr=1.0
       ! create the center coordinates for the pixels
       call output("Calculate pixel coordinates ...")
       do i = 1, npix ! center coordinates of pixels in cm
         im_coord(i) = delpix/2d0 + delpix*(i - 1) - Rout*AU
       end do
-            
+
       ! map the paths to the pixel, need to do it for each grid
       !do i = 1, ngrids
       call output("map grid "//int2string(1, '(i7)')//" to pixels")
@@ -96,15 +105,16 @@
       ! Allocate per-path, per-(cube-bin, vmult-side) continuum-done flags.
       ! Dim2: 1 = vmult=-1 side, 2 = vmult=+1 side.
       do j = 1, npoints(1)
-        allocate(P(1,j)%imcube_cont_done(nlam_cube, 2))
-        P(1,j)%imcube_cont_done = .false.
+        allocate (P(1, j)%imcube_cont_flux(nlam_cube, 2))
+        P(1, j)%imcube_cont_flux = -1.0
       end do
-      allocate(path2star%imcube_cont_done(nlam_cube, 2))
-      path2star%imcube_cont_done = .false.
+      allocate (path2star%imcube_cont_flux(nlam_cube, 2))
+      path2star%imcube_cont_flux = -1.0
 
-      call output("Image cube has "//trim(int2string(nlam_cube, '(i7)'))//" channels (dlam="//trim(dbl2string(dlam_cube, '(F11.4)'))//") and "//trim(int2string(npix*npix, '(i7)'))//" pixels.")
+      call output("Image cube has "//trim(int2string(nlam_cube, '(i7)'))//" channels (dlam="//trim(dbl2string(dlam_cube, '(1pE15.7)'))//") and "//trim(int2string(npix*npix, '(i7)'))//" pixels.")
       call output("Image cube size: "//trim(dbl2string(sizeof(imcube)/1.e9, '(F11.4)'))//" GB")
       call clock_write(time, utime, "Prepare image cube: ")
+
     end if
 
     lam = lmin
@@ -180,59 +190,80 @@
 
           call clock(timegap, utimegap)
 
-          ! here lcmin is the wl that was done in the last blend, 
+          ! here lcmin is the wl that was done in the last blend,
           ! Something is fishy here, bzt Bl%lmax is not the maximum wavelength that is actually done
-          lamgapmax=lam*sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
-          do i = 1, nlam_cube ! check if lcmin is  not in the current cube bin            
-            if ((lamb_cube(i+1) > lcmin .and. lamb_cube(i+1) < Bl%lmin) .or. &
+          lamgapmax = lamvelo(lam,BL%nvmax)
+          lamgapmin = lamvelo(lam,BL%nvmin)
+          do i = 1, nlam_cube ! check if lcmin is  not in the current cube bin
+            if ((lamb_cube(i + 1) > lmin_next .and. lamb_cube(i + 1) < lamgapmin) .or. &
                 (iblends == nblends .and. lamb_cube(i) > lamgapmax)) then ! this is for the end
               ilam_cube_start = min(ilam_cube_start, i)
               ilam_cube_end = max(ilam_cube_end, i)
             end if
           end do
-          ! I have some gap          
-          if (ilam_cube_start <= ilam_cube_end) then            
+          !write(*,*) "lamgap: ",lamgapmax,lmin_next,lcmin,Bl%lmin,Bl%lmax,lamb_cube(i+1),ilam_cube_start,ilam_cube_end,lam_cube(ilam_cube_start),lam_cube(ilam_cube_end)
+          ! I have some gap
+          if (ilam_cube_start <= ilam_cube_end) then
             call output("  Fill imcube gap from lam "//dbl2string(lam_cube(ilam_cube_start))//" to"//dbl2string(lam_cube(ilam_cube_end))//" with continuum.")          
             !write(*,*) Bl%lmin, Bl%lmax,lamgapmax, lcmin, lamb_cube(ilam_cube_start),lam_cube(ilam_cube_start),lam_cube(ilam_cube_end)
             do i = ilam_cube_start, ilam_cube_end
               !if ((lam_cube(i) > lcmin .and. lam_cube(i) < Bl%lmin) .or. &
               !    (iblends == nblends .and. lam_cube(i) > Bl%lmax)) then ! this is for the end
-                ilam_cube_gap = 1
-                do while (lam_cube(i) > lam_cont(ilam_cube_gap + 1) .and. ilam_cube_gap < nlamCont)
-                  ilam_cube_gap = ilam_cube_gap + 1
-                end do
-                call InterpolateLam(lam_cube(i), ilam_cube_gap)
+              ilam_cube_gap = 1
+              do while (lam_cube(i) > lam_cont(ilam_cube_gap + 1) .and. ilam_cube_gap < nlamCont)
+                ilam_cube_gap = ilam_cube_gap + 1
+              end do
+              call InterpolateLam(lam_cube(i), ilam_cube_gap)
 !$OMP PARALLEL DEFAULT(NONE) &
 !$OMP PRIVATE(j,PP, flux0,vmult) &
 !$OMP SHARED(P, npoints, lam_cube, i, igrid, ngrids)
 !$OMP DO SCHEDULE(dynamic,1)
-                do j = 1, npoints(1)  ! just do it for the first grid for imagecube
-                  PP => P(1, j)
-                  call ContContrPath(PP, flux0)
-                  do vmult=-1,1,2
-                    call AddImage(0, lam_cube(i), flux0*PP%A/2d0, PP, vmult, "continuum in gap", .true.)                  
-                  end do
+              do j = 1, npoints(1)  ! just do it for the first grid for imagecube
+                PP => P(1, j)
+                call ContContrPath(PP, flux0)
+                do vmult = -1, 1, 2
+                  call AddImage(lam_cube(i), flux0*PP%A/2d0, flux0*PP%A/2d0, PP, vmult, "cont0")
                 end do
+              end do
 !$OMP END DO
 !$OMP END PARALLEL
-                ! do the star, as there are no lines, nb = 0
-                PP => path2star                
-                call Trace2StarLines(PP, flux0, 0, imol_blend, v_blend, 0)    
-                ! for the star we correct the area as the pixel is usually much larger than the star            
-                call AddImage(0, lam_cube(i), flux0*PP%A*starcorr, PP, 1, "trace star gap", .true.)
+              ! do the star, as there are no lines, nb = 0
+              PP => path2star
+              call Trace2StarLines(PP, flux0, 0, imol_blend, v_blend, 0)
+              ! for the star we correct the area as the pixel is usually much larger than the star
+              call AddImage(lam_cube(i), flux0*PP%A*starcorr, flux0*PP%A*starcorr, PP, 1, "star0")
               !end if
             end do
-            call clock_write(timegap, utimegap,"  Fill imcube gap: ")
+            call clock_write(timegap, utimegap, "  Fill imcube gap: ")
           end if
         end if
 
         if (iblends == 1) then
           call output("  First line blend ("//trim(int2string(nb, '(i4)'))//" lines at lamcenter="//(dbl2string(Bl%lam, '(F10.3)'))//" micron)")
         end if
+
+        ! Search for the first wl of the current blend, which is actually calculated
         
+        !write(*,*) lam_cont(ilam1Cont),lam_cont(ilam1Cont+1), lcmin, Bl%lmin, Bl%lmax, lmin_next        
+        lam_interpolate=lam
+        ! do iv=Bl%nvmin, Bl%nvmax
+        !   lam_velo = lamvelo(lam, iv)
+
+        !   ! keep old behaviour for those cases
+        !   if ((lam_velo >= lmax).or.(lam_velo > lam_cont(ilam1Cont+1))) then             
+        !     exit
+        !   endif
+
+        !   if (lam_velo > lmin_next) then
+        !     write(*,*) "  First wl to be calculated for this blend: ", lam_velo,Bl%nvmin,iv,Bl%nvmax, " (blend center: ", lam, " )",lmin_next
+        !     Bl%nvmin = iv
+        !     lam_interpolate=lamvelo(lam, iv)
+        !     exit
+        !   end if
+        ! end do        
 
         ilam = ilam1Cont
-        do while (lam > lam_cont(ilam + 1) .and. ilam < nlamCont)
+        do while (lam_interpolate > lam_cont(ilam + 1) .and. ilam < nlamCont)
           ilam = ilam + 1
           if (ilam == nlamCont) exit
         end do
@@ -258,7 +289,7 @@
 
         lcmin = Bl%lmax
 
-        call InterpolateLam(lam, ilam)
+        call InterpolateLam(lam_interpolate, ilam)
         do i = 0, nR
           do j = 1, nTheta
             do ilines = 1, Bl%n
@@ -270,15 +301,15 @@
           end do
         end do
 
+        ! Collects all the pure continuum contributions, for the current blend
         flux2 = 0d0
 
         ! randomly select a grid.
-        if (imagecube) then 
-          i=1
+        if (imagecube) then
+          i = 1
         else
           i = int(ran1(idum)*real(ngrids) + 1)
-        endif
-        
+        end if
 
         ! FIXME: check parallel implementation for imagecube
 !$OMP PARALLEL IF(.true.) &
@@ -288,7 +319,7 @@
 !$OMP SHARED(iblends,flux2,maxblend,lam,lmin_next,imagecube,nvmin,nvmax)
         allocate (doit_ib0(maxblend))
         allocate (doit_ib(maxblend))
-        allocate (flux4(nvmin:nvmax))
+        allocate (flux4(nvmin:nvmax),source=0.d0)
 
 #ifdef _OPENMP
         idum = -42 - OMP_GET_THREAD_NUM()     ! setting the seed
@@ -317,7 +348,8 @@
             !write(*,*) "doit",i,j
             !write(*,*) Bl%nvmin,Bl%nvmax
             do iv = Bl%nvmin, Bl%nvmax
-              lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
+              lam_velo = lamvelo(lam, iv)
+              ! this check avaoids tracing wavelengths that have already be done in the previous blend
               if (lam_velo > lmin_next) then
                 vmult = 1
                 if (nb > 1) then
@@ -354,17 +386,15 @@
                     end do
                     if (gas) then
                       call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
-                      if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, callerstr, .false.)
+                      if (imagecube) call AddImage(lam_velo, flux0*PP%A/2d0, flux_c*PP%A/2d0, PP, vmult, "gas")
                     else
                       flux0 = flux_c
                       !write (callerstr, "(A,' ' ,i5,A,F10.3,A,F10.3)") "call nb ", iblends,"lmin:",lmin_next,"lv:",lam_velo
                       ! Fixed: imcube_cont_done flag in AddImage prevents double-counting when multiple
                       ! blend channels map to the same cube bin with no gas.
-                      if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, "cont", .true.)
+                      if (imagecube) call AddImage(lam_velo, flux0*PP%A/2d0, flux0*PP%A/2d0, PP, vmult, "cont1")
                     end if
                     flux4(iv) = flux4(iv) + flux0*PP%A/2d0
-                    !write (callerstr, "(A,' ' ,i5,A,F10.3,A,F10.3)") "call nb ", iblends,"lmin:",lmin_next,"lv:",lam_velo
-                    !if (imagecube) call AddImage(iv, lam, flux0*PP%A/2d0, PP, vmult, callerstr)
                   end do
                   ! channel fully outside the line, so just add the continuum contribution
                 else if (((real(iv) + 0.5d0)*vresolution > PP%vmax(LL%imol) .and. &
@@ -375,10 +405,8 @@
                   do vmult = -1, 1, 2
                     flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0
                     ! Seems to be required here and is done twice
-                    ! FIXME: callerstring is only for debugging, remove it
-                    write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else if", iv, vmult
                     if (imagecube) then
-                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, "cont", .true.)
+                      call AddImage(lamvelo(lam, iv*vmult), flux0*PP%A/2d0, flux0*PP%A/2d0, PP, vmult, "cont2")
                     end if
                   end do
                   ! channel covers single line (not blended)
@@ -386,29 +414,28 @@
                   doit_ib = .true.
                   call TraceFluxLines(PP, flux0, iv, vmult, imol_blend, v_blend, doit_ib, nb, 1)
                   do vmult = -1, 1, 2
-                    flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0
-                    write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else", iv, vmult
+                    flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0 ! TODO: Why here *vmult
                     if (imagecube) then
-                      call AddImage(iv*vmult, lam, flux0*PP%A/2d0, PP, vmult, callerstr, .false.)
+                      call AddImage(lamvelo(lam, iv*vmult), flux0*PP%A/2d0, flux_c*PP%A/2d0, PP, vmult, "gas2")
                     end if
                   end do
                 end if
               end if
             end do
           else
-            !write(*,*) "call not doit", not populated
-            ! not sure why here we do not use vmult treatment
+            ! not doit, not populated, just add the continuum
+            ! FIXME: not sure why here vmult is not used
             flux0 = flux_c
             flux4(Bl%nvmin:Bl%nvmax) = flux4(Bl%nvmin:Bl%nvmax) + flux0*PP%A
             if (imagecube) then ! do the vmult treatment for the image cube, important where the flux is
               do vmult = -1, 1, 2
                 do iv = Bl%nvmin, Bl%nvmax
-                  lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
+                  lam_velo = lamvelo(lam, iv)                  
                   if (lam_velo > lmin_next) then
-                    call AddImage(iv, lam, flux0*PP%A, PP, vmult, "call not doit", .true.)
-                  endif
+                    call AddImage(lam_velo, flux0*PP%A/2.0, flux0*PP%A/2.0, PP, vmult, "cont4")
+                  end if
                 end do
-              end do 
+              end do
             end if
           end if
         end do
@@ -425,56 +452,64 @@
         ! do the star
         if (.not. allocated(PP%im_ixy)) allocate (PP%im_ixy(2, 1))
         do iv = Bl%nvmin, Bl%nvmax
-          if (nb > 1) then  ! FIXME: this if seems to be unnecessary
+          lam_velo = lamvelo(lam, iv)
+          if (lamvelo(lam, iv) > lmin_next) then
             call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
             flux(iv) = flux(iv) + flux0*PP%A
-          else
-            call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
-            flux(iv) = flux(iv) + flux0*PP%A
-          end if
-          if (imagecube) call AddImage(iv, lam, flux0*PP%A*starcorr, PP, 1, "trace star", .false.)
+            if (imagecube) then            
+              call AddImage(lamvelo(lam, iv), flux0*PP%A*starcorr, flux0*PP%A*starcorr, PP, 1, "star1")
+            end if
+          endif
         end do
+        ! this adds the flux of the star from the last iv (nvmax), is strange, but does not matter, is removed afterwards anyway.
         flux2 = flux2 + flux0*PP%A
 
-        flux1 = 0d0
-        flux3 = 0d0
+        if (.true.) then
+          flux1 = 0d0
+          flux3 = 0d0
 
-        f = sqrt((1d0 + real(Bl%nvmin)*vresolution/clight)/(1d0 - real(Bl%nvmin)*vresolution/clight))
-        wl11 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-        ! wl11 can be > 1 if nv*vresolution is wider than the spacing between the continuum points.
-        ! So the continuum grid is too fine, just assume the nearest continuum point then.
-        ! > 1 would mean extrapolation, but in some cases that ends in NaN, limiting it to 1 means, no extrapolation
-        wl11 = min(1d0, max(0d0, wl11))
-        wl21 = 1d0 - wl11
+          ! The following block determines the more accurate continuum (as all grids are used) that
+          ! was raytraced before (RaytraceContinuum)
+          ! Those results are interpolated for the current blend grid
+          f = sqrt((1d0 + real(Bl%nvmin)*vresolution/clight)/(1d0 - real(Bl%nvmin)*vresolution/clight))
+          wl11 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+          ! wl11 can be > 1 if nv*vresolution is wider than the spacing between the continuum points.
+          ! So the continuum grid is too fine, just assume the nearest continuum point then.
+          ! > 1 would mean extrapolation, but in some cases that ends in NaN, limiting it to 1 means, no extrapolation
+          wl11 = min(1d0, max(0d0, wl11))
+          wl21 = 1d0 - wl11
 
-        f = sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
-        wl13 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-        ! see above wl11
-        wl13 = min(1d0, max(0d0, wl13))
-        wl23 = 1d0 - wl13
+          f = sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
+          wl13 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+          ! see above wl11
+          wl13 = min(1d0, max(0d0, wl13))
+          wl23 = 1d0 - wl13
 
-        flux_l1 = 0d0
-        flux_l2 = 0d0
-        do k = 1, ngrids
-          do j = 1, npoints(k)
-            PP => P(k, j)
-            flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A/real(ngrids)
-            flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A/real(ngrids)
+          flux_l1 = 0d0
+          flux_l2 = 0d0
+          do k = 1, ngrids
+            do j = 1, npoints(k)
+              PP => P(k, j)
+              flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A/real(ngrids)
+              flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A/real(ngrids)
+            end do
           end do
-        end do
-        PP => path2star
+          PP => path2star
 
-        flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A
-        flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A
+          flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A
+          flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A
 
-        flux1 = flux_l1**wl11*flux_l2**wl21
-        flux3 = flux_l1**wl13*flux_l2**wl23
+          flux1 = flux_l1**wl11*flux_l2**wl21
+          flux3 = flux_l1**wl13*flux_l2**wl23
 
-        do iv = Bl%nvmin, Bl%nvmax
-          fc = flux1 + (flux3 - flux1)*real(iv - Bl%nvmin)/real(Bl%nvmax - Bl%nvmin)
-          flux(iv) = flux(iv) - flux2 + fc
-          flux_cont(iv) = fc
-        end do
+          do iv = Bl%nvmin, Bl%nvmax
+            fc = flux1 + (flux3 - flux1)*real(iv - Bl%nvmin)/real(Bl%nvmax - Bl%nvmin)
+            flux(iv) = flux(iv) - flux2 + fc
+            flux_cont(iv) = fc
+          end do
+        else
+          flux_cont(:) = flux2
+        end if
 
         if (Bl%n == 1) then
           comment = trim(Mol(Bl%L(1)%imol)%name)//"  up: "//trim(int2string(Bl%L(1)%jup, '(i5)')) &
@@ -494,13 +529,13 @@
         end if
 
         Bl%F = 0d0
-        lam_velo = lam*sqrt((1d0 + vresolution/clight)/(1d0 - vresolution/clight))
+        lam_velo = lamvelo(lam, 1)
         dnu = dabs(clight*1d4*(1d0/lam_velo - 1d0/lam))
         lam_w = 0d0
         lam_w_min = 1d200
         lam_w_max = 0d0
         do iv = Bl%nvmin, Bl%nvmax
-          lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
+          lam_velo = lamvelo(lam, iv)
           if (lam_velo > lmin_next) then
             write (20, "(F15.8, 1pE16.8, 1pE16.8, 1pE16.8, 3X, A)") lam_velo, &
               flux(iv)*1e23/(distance*parsec)**2, &
@@ -519,6 +554,8 @@
         Bl%F = Bl%F*1d-3/(distance*parsec)**2
         write (21, *) lam_w, Bl%F, lam_w_min, lam_w_max, trim(comment)
 
+        ! lam_velo hisre is lamvelo(lam,Bl%nvmax), so it should be BL%lmax ?
+        !write(*,*) lmin_next,lam_velo
         lmin_next = max(lmin_next, lam_velo)
 
       end if ! if(lam>lmin.and.lam<lmax)
@@ -533,9 +570,10 @@
       call output("")
       call output("Writing image cube to file imcube.fits ...")
       call writefitsfile(trim(imagecube_filename), imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin, lmin, .true.)
-      call output("")      
+      call output("")
     end if
 
+    ! if necessary (i.e. not reached lmax), write the continuum only points
     ilam = ilam + 1
     do while (ilam <= nlamCont)
       if (lam_cont(ilam) < lmax) then
@@ -568,14 +606,27 @@
     return
   end subroutine RaytraceLines
 
+  real function lamvelo(reflam, iv)
+    ! Gets the abs. wavelength for the given velocity channel
+    !
+    ! reflam: is the rest wavelength of the line
+    ! iv:     velocity channel, e.g. -10, -9, ..., 0, ..., +9, +10 for nv=10
+    !
+    use GlobalSetup
+    use Constants
+    real(kind=8), intent(in) :: reflam
+    integer, intent(in) :: iv
+    lamvelo = reflam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
+  end function lamvelo
+
   subroutine ContContrPath(p0, flux)
-!   Compute the continuum flux along path p0 at the current line-center
-!   wavelength (set by the last call to InterpolateLam). Integrates the
-!   formal RT solution cell by cell using the pre-interpolated dust opacity
-!   kext_l and source function (therm_l + scat_l). As a side effect, caches
-!   exptau_dust(k), S_dust(k) and cont_contr(k) per path element so that
-!   TraceFluxLines can reuse them without recomputing the dust RT.
-! DOC by Claude
+    !   Compute the continuum flux along path p0 at the current line-center
+    !   wavelength (set by the last call to InterpolateLam). Integrates the
+    !   formal RT solution cell by cell using the pre-interpolated dust opacity
+    !   kext_l and source function (therm_l + scat_l). As a side effect, caches
+    !   exptau_dust(k), S_dust(k) and cont_contr(k) per path element so that
+    !   TraceFluxLines can reuse them without recomputing the dust RT.
+    ! DOC by Claude
     use GlobalSetup
     use Constants
     implicit none
@@ -763,11 +814,11 @@
     integer :: i, iv, j
     real(kind=8) :: maxvshift, maxmult, v, f
     type(Blend), pointer :: Bl
-    real(kind=8) :: time,utime
+    real(kind=8) :: time, utime
 
-    call clock(time,utime)
+    call clock(time, utime)
     call output("")
-    call output("Determining blends...")        
+    call output("Determining blends...")
 
     maxvshift = 2d0*real(nv)*vresolution
     maxmult = sqrt((1d0 + maxvshift/clight)/(1d0 - maxvshift/clight))
@@ -927,7 +978,7 @@
     end do
 
     do i = 1, npix
-      call tellertje(i,npix)
+      call tellertje(i, npix)
       im_x = im_coord(i)
       ! only care about the positive half
       do j = int(npix/2 + 1), npix
@@ -994,8 +1045,14 @@
 
   end subroutine map_pixels_to_path
 
-  subroutine AddImage(iv, lam_blend, flux0, p0, vmult, caller, is_cont)
-    ! Maps velocity channel iv (relative to lam_blend) to the global linear
+  integer function ivcube(lam_velo)
+    use GlobalSetup
+    real(kind=8), intent(in) :: lam_velo
+    ivcube = idnint((lam_velo - lam_cube(1))/dlam_cube) + 1
+  end function ivcube
+
+  subroutine AddImage(lam_velo, flux0, fluxcont, p0, vmult, caller)
+    ! Maps lam_velo to the global linear
     ! wavelength grid and accumulates flux into imcube.
     ! is_cont=.true. marks a pure-continuum contribution: the call is skipped if this
     ! (cube_bin, vmult-side) has already been filled for this path, preventing double-counting
@@ -1004,66 +1061,82 @@
     use Constants
     use InOut
     implicit none
-    integer, intent(in) :: iv
-    real(kind=8), intent(in) :: lam_blend
+    real(kind=8), intent(in) :: lam_velo
     real(kind=8), intent(in) :: flux0
+    real(kind=8), intent(in) :: fluxcont
     integer, intent(in) :: vmult
     type(Path), intent(inout) :: p0
     character(len=*), intent(in) :: caller        ! just for logging, can be removed
-    logical, intent(in) :: is_cont
-    integer :: ix, iy, ipix, ivcube, ivmult_idx
-    real(kind=8) :: fluxperpix, lam_velo
+    integer :: ix, iy, ipix, ivc, ivmult_idx, ivcube
+    real(kind=8) :: fluxperpix, fluxadd
 
-    ! the cube goes strictly from lmin (channel centers) to lmax, but parts of a bleand can be outside    
-    ! compute absolute wavelength for this channel and map to global cube index
-    lam_velo = lam_blend*sqrt((1d0 + real(iv)*vresolution/clight)/ &
-                              (1d0 - real(iv)*vresolution/clight))
-    if (lam_velo<lamb_cube(1) .or. lam_velo>lamb_cube(nlam_cube+1)) then
+    ! the cube goes strictly from lmin (channel centers) to lmax, but parts of a blend can be outside
+    if (lam_velo < lamb_cube(1) .or. lam_velo > lamb_cube(nlam_cube + 1)) then
       ! this can happen for the channels at the edge of the blend, just ignore those.
       return
     end if
 
-    ivcube = idnint((lam_velo - lam_cube(1))/dlam_cube) + 1
-    ! Sanity check
-    if (lam_velo<lamb_cube(ivcube).or.lam_velo>lamb_cube(ivcube+1)) then
-      write(*,*) ivcube,lam_velo, lamb_cube(ivcube), lam_cube(ivcube),lamb_cube(ivcube+1)
-      call output("Warning: velocity channel iv="//trim(int2string(iv, '(i5)'))// &
-                  " at lam_velo="//trim(dbl2string(lam_velo, '(f15.8)'))// &
+    ivc = ivcube(lam_velo)
+    ivmult_idx = (vmult + 3)/2 ! for symmetry treatment
+    ! FIXME: remove Sanity check, should reall not happen
+    if (lam_velo < lamb_cube(ivc) .or. lam_velo > lamb_cube(ivc + 1)) then
+      write (*, *) ivc, lam_velo, lamb_cube(ivc), lam_cube(ivc), lamb_cube(ivc + 1)
+      call output("Warning: lam_velo="//trim(dbl2string(lam_velo, '(f15.8)'))// &
                   " is outside of the cube limits. Skipping this channel for the image cube. Caller: "//trim(caller))
       stop
     end if
     !write(*,*) caller," ", lam_blend,lam_velo,lmin,ivcube
-    ! some parts of the line can be outside of the cube limits, we ignore those.
-    if (ivcube < 1 .or. ivcube > nlam_cube) return
+
+    ! FIXME: Assume that continuum can never be < 0
+    ! if continuum is still < 0, we add the continuum the first time.
+    fluxadd = flux0
+    ! if we have added already a continuum, remove it again.
+    if (.not. (p0%imcube_cont_flux(ivc, ivmult_idx) < 0)) then
+      fluxadd = flux0 - fluxcont
+    else
+      fluxadd = flux0
+    end if
+    p0%imcube_cont_flux(ivc, ivmult_idx) = fluxcont
+    ! if (ivc == 873.or.ivc == 875) then
+    !   write(*,*) "AddImage1: ", ivc,trim(caller), lam_velo, lam_cube(ivc), flux0, fluxcont, fluxadd
+    ! end if
+    ! if (ivc == 874) then
+    !   write(*,*) "AddImage2: ", trim(caller), lam_velo, lam_cube(ivc), vmult, flux0, fluxcont, fluxadd
+    ! end if
 
     ! Guard continuum-only contributions: each (cube_bin, vmult-side) must be filled at most once
     ! per path to prevent double-counting when multiple blend channels map to the same bin.
     ! ivmult_idx: 1 = vmult=-1, 2 = vmult=+1
-    ivmult_idx = (vmult + 3) / 2
-    if (is_cont) then
-      if (p0%imcube_cont_done(ivcube, ivmult_idx)) return
-      p0%imcube_cont_done(ivcube, ivmult_idx) = .true.
-    end if
 
-    fluxperpix = flux0/p0%im_npix    
+    ! if (is_cont) then
+    !   ivmult_idx = (vmult + 3) / 2
+    !   if (ivc==11) then
+    !      write(*,*) "Check cont guard: ", trim(caller), lam_velo, ivc, vmult, p0%im_npix, p0%im_ixy(:, 1:p0%im_npix),p0%imcube_cont_done(ivc, ivmult_idx)
+    !   end if
+    !   if (p0%imcube_cont_done(ivc, ivmult_idx)) return
+    !   p0%imcube_cont_done(ivc, ivmult_idx) = .true.
+    ! end if
+
+    fluxperpix = fluxadd/p0%im_npix
 
     do ipix = 1, p0%im_npix
 
       ix = p0%im_ixy(1, ipix)
-      iy = p0%im_ixy(2, ipix) 
+      iy = p0%im_ixy(2, ipix)
 
       ! assume here x and y = 0 at the center of the image
       if (vmult < 0) then
         iy = npix - (iy - 1) ! for mirroring the whole thing
       end if
 
-      imcube(iy, ix, ivcube) = imcube(iy, ix, ivcube) + fluxperpix ! P%y (Vertical) seems to be along the major axis - make it x
+      ! needs atomic as different paths can contribute to the same pixels
+  !$OMP ATOMIC
+      imcube(iy, ix, ivc) = imcube(iy, ix, ivc) + fluxperpix ! P%y (Vertical) seems to be along the major axis - make it x
     end do
 
-    ! if (ivcube==57) then
-    !   !write(*,*) lamb_cube(57),lam_cube(57),lamb_cube(58)
-    !   write(*,*) "caller: ", trim(caller), " iv: ", iv, " lam_blend: ", lam_blend, " lam_velo: ", lam_velo, " ivcube: ", ivcube, vmult,p0%im_npix,fluxperpix,p0%x,p0%y,ix,iy      
-    ! end if  
+    ! if (ivc==11) then
+    !    write(*,*) lamb_cube(11),lam_cube(11),lamb_cube(11+1),"caller: ", trim(caller), " lam_velo: ", lam_velo, " ivc: ", ivc, vmult,p0%im_npix,fluxperpix,p0%x,p0%y,ix,iy
+    ! end if
 
     return
   end subroutine AddImage

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -260,10 +260,7 @@
           ilam1Cont = ilam
         end if
 
-        write(*,*) "Blend: ",iblends,lcmin, Bl%lmin, Bl%lmax, lam, nb,lmin_next
-
         lcmin = Bl%lmax
-        write(*,*) "Blend: ",iblends,lcmin, Bl%lmin, Bl%lmax, lam, nb,lmin_next
 
         call InterpolateLam(lam, ilam)
         do i = 0, nR

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -66,9 +66,9 @@
     end if
     
     lam = lmin
-    ilam1 = 1
-    do while (lam > lam_cont(ilam1 + 1) .and. ilam1 < nlamCont)
-      ilam1 = ilam1 + 1
+    ilam1Cont = 1
+    do while (lam > lam_cont(ilam1Cont + 1) .and. ilam1Cont < nlamCont)
+      ilam1Cont = ilam1Cont + 1
     end do
 
     allocate (profile(-nvprofile:nvprofile))
@@ -135,15 +135,15 @@
       if (lam > lmin .and. lam < lmax) then
         nl = nl + nb
 
-        ilam = ilam1
+        ilam = ilam1Cont
         do while (lam > lam_cont(ilam + 1) .and. ilam < nlamCont)
           ilam = ilam + 1
           if (ilam == nlamCont) exit
         end do
 
         ! that writes out continuum only points for the spectrum.
-        if (ilam > ilam1) then
-          do k = ilam1 + 1, ilam
+        if (ilam > ilam1Cont) then
+          do k = ilam1Cont + 1, ilam
             if (lam_cont(k) > lcmin .and. lam_cont(k) < Bl%lmin) then
               flux0 = 0d0
               do i = 1, ngrids
@@ -157,7 +157,7 @@
                 flux0*1e23/(distance*parsec)**2, 0.0, flux0*1e23/(distance*parsec)**2, "continuum"
             end if
           end do
-          ilam1 = ilam
+          ilam1Cont = ilam
         end if
         lcmin = Bl%lmax
 

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -1,419 +1,481 @@
-subroutine RaytraceLines()
-  use GlobalSetup
-  use Constants
-  use InOut
-  implicit none
-  integer :: i, j, ilam, k, iblends, vmult, iv, nv, nl, imol, maxblend, ilines, nvmax, nvmin
-  integer :: nb, ib0, nb0, ib, nltot
-  integer(kind=4) :: counts, count_rate, count_max
-  integer, external :: OMP_GET_THREAD_NUM
-  integer, allocatable :: imol_blend(:), count(:)
-  real(kind=8), allocatable :: v_blend(:), flux4(:)
-  real(kind=8) :: lam, flux0, starttime, stoptime, fact, lcmin
-  real(kind=8) :: lmin_next, lam_velo
-  real(kind=8), allocatable :: flux(:), flux_cont(:)
-  type(Path), pointer :: PP
-  type(Line) :: LL
-  type(Blend), pointer :: Bl
-  logical :: gas, doit
-  logical, allocatable :: doit_ib(:), doit_ib0(:)
-  real(kind=8) :: flux1, flux2, flux3, fc, f, dnu, lam_w, lam_w_min, lam_w_max
-  real(kind=8) :: wl11, wl21, wl13, wl23, flux_l1, flux_l2, flux_c
-  character(len=1000) :: comment
-  character(len=500) :: imcubename
-  real(kind=8) :: time, utime
+  subroutine RaytraceLines()
+    use GlobalSetup
+    use Constants
+    use InOut
+    implicit none
+    integer :: i, j, ilam, k, iblends, vmult, iv, nv, nl, imol, maxblend, ilines, nvmax, nvmin
+    integer :: nb, ib0, nb0, ib, nltot
+    integer(kind=4) :: counts, count_rate, count_max
+    integer, external :: OMP_GET_THREAD_NUM
+    integer, allocatable :: imol_blend(:), count(:)
+    real(kind=8), allocatable :: v_blend(:), flux4(:)
+    real(kind=8) :: lam, flux0, starttime, stoptime, fact, lcmin
+    real(kind=8) :: lmin_next, lam_velo, lam_velo_imcube
+    real(kind=8), allocatable :: flux(:), flux_cont(:)
+    type(Path), pointer :: PP
+    type(Line) :: LL
+    type(Blend), pointer :: Bl
+    logical :: gas, doit
+    logical, allocatable :: doit_ib(:), doit_ib0(:)
+    real(kind=8) :: flux1, flux2, flux3, fc, f, dnu, lam_w, lam_w_min, lam_w_max
+    real(kind=8) :: wl11, wl21, wl13, wl23, flux_l1, flux_l2, flux_c
+    character(len=1000) :: comment
+    character(len=500) :: imcubename
+    character(len=40) :: callerstr
+    real(kind=8) :: delpix
+    real(kind=8) :: time, utime
 
-  call output("==================================================================")
-  call output("Preparing the profiles")
+    call output("==================================================================")
+    call output("Preparing the profiles")
 
-  do i = 1, ngrids
-    do j = 1, npoints(i)
-      allocate (P(i, j)%cont_contr(P(i, j)%n))
-      allocate (P(i, j)%exptau_dust(P(i, j)%n))
-      allocate (P(i, j)%S_dust(P(i, j)%n))
+    do i = 1, ngrids
+      do j = 1, npoints(i)
+        allocate (P(i, j)%cont_contr(P(i, j)%n))
+        allocate (P(i, j)%exptau_dust(P(i, j)%n))
+        allocate (P(i, j)%S_dust(P(i, j)%n))
+      end do
     end do
-  end do
 
-  open (unit=20, file=outputFile, RECL=1500)
-  open (unit=21, file=output_lineFluxFile, RECL=1500)
-  write (21, '("# lam[mu]   Fline[W/m^2]    lmin[mu]    lmax[mu]    comment")')
+    open (unit=20, file=outputFile, RECL=1500)
+    open (unit=21, file=output_lineFluxFile, RECL=1500)
+    write (21, '("# lam[mu]   Fline[W/m^2]    lmin[mu]    lmax[mu]    comment")')
 
-  nv = int(vmax*1.1/vresolution) + 1
-  nvprofile = int(vmax*vres_mult/vresolution)
+    nv = int(vmax*1.1/vresolution) + 1
+    nvprofile = int(vmax*vres_mult/vresolution)
 
-  call DetermineBlends(nv, maxblend, nvmin, nvmax)
+    ! this should always give nvmin=-nv and nmvmax=nv
+    call DetermineBlends(nv, maxblend, nvmin, nvmax)
 
-  allocate (flux(nvmin:nvmax))
-  allocate (flux_cont(nvmin:nvmax))
-  allocate (imol_blend(maxblend))
-  allocate (v_blend(maxblend))
-  allocate (count(nmol))
+    allocate (flux(nvmin:nvmax))
+    allocate (flux_cont(nvmin:nvmax))
+    allocate (imol_blend(maxblend))
+    allocate (v_blend(maxblend))
+    allocate (count(nmol))
 
-  if (imagecube) then
-    allocate (imcube(npix, npix, nvmin:nvmax))
-  end if
-
-  lam = lmin
-  ilam1 = 1
-  do while (lam > lam_cont(ilam1 + 1) .and. ilam1 < nlam)
-    ilam1 = ilam1 + 1
-  end do
-  allocate (profile(-nvprofile:nvprofile))
-  allocate (profile_nz(-nvprofile:nvprofile))
-  do i = 0, nR
-    do j = 0, nTheta
-      allocate (C(i, j)%line_abs(maxblend))
-      allocate (C(i, j)%line_emis(maxblend))
-    end do
-  end do
-
-  do k = -nvprofile, nvprofile
-    profile(k) = ((real(k)*vresolution/vres_mult)/1d5)**2
-    if (abs(profile(k)) < 10d0) then
-      profile_nz(k) = .true.
-    else
-      profile_nz(k) = .false.
-    end if
-  end do
-  profile(:) = exp(-profile(:))
-
-  nl = 0
-
-  call output("==================================================================")
-
-  call clock(time, utime)
-  
-  call SYSTEM_CLOCK(counts, count_rate, count_max)
-  starttime = DBLE(counts)/DBLE(count_rate)
-
-  call output("Tracing "//trim(int2string(nlines, '(i6)'))//" lines")
-
-  lcmin = lmin
-  lmin_next = 0d0
-
-  nltot = 0
-  Bl => Blends
-  do iblends = 1, nblends
-    nltot = nltot + Bl%n
-    if (iblends < nblends) Bl => Bl%next
-  end do
-  call output("Total number of wl/velocity points: "//trim(int2string(nltot, '(i7)')))
-
-  Bl => Blends
-  do iblends = 1, nblends
     if (imagecube) then
-      imcube = 0d0
+      allocate (imcube(npix, npix, nvmin:nvmax))
+      allocate (imcube_hit(npix, npix, nvmin:nvmax))
+      allocate (im_coord(npix))
+      delpix = 2.d0*Rout*AU/real(npix)
+      ! create the center coordinates for the pixels
+      do i = 1, npix ! center coordinates of pixels in cm
+        im_coord(i) = delpix/2d0 + delpix*(i - 1) - Rout*AU
+      end do
+      !write(*,*) im_coord/AU
+
     end if
-    flux = 0d0
 
-    nb = Bl%n
-    if (iblends == 1) call output("First line blend ("//trim(int2string(nb, '(i4)'))//" lines)")
-
-    do ib = 1, nb
-      imol_blend(ib) = Bl%L(ib)%imol
-      v_blend(ib) = Bl%v(ib)
+    lam = lmin
+    ilam1 = 1
+    do while (lam > lam_cont(ilam1 + 1) .and. ilam1 < nlam)
+      ilam1 = ilam1 + 1
+    end do
+    allocate (profile(-nvprofile:nvprofile))
+    allocate (profile_nz(-nvprofile:nvprofile))
+    do i = 0, nR
+      do j = 0, nTheta
+        allocate (C(i, j)%line_abs(maxblend))
+        allocate (C(i, j)%line_emis(maxblend))
+      end do
     end do
 
-    LL = Bl%L(1)
-    lam = Bl%lam
+    do k = -nvprofile, nvprofile
+      profile(k) = ((real(k)*vresolution/vres_mult)/1d5)**2
+      if (abs(profile(k)) < 10d0) then
+        profile_nz(k) = .true.
+      else
+        profile_nz(k) = .false.
+      end if
+    end do
+    profile(:) = exp(-profile(:))
 
-    if (lam > lmin .and. lam < lmax) then
-      nl = nl + nb
+    nl = 0
 
-      ilam = ilam1
-      do while (lam > lam_cont(ilam + 1) .and. ilam < nlam)
-        ilam = ilam + 1
-        if (ilam == nlam) exit
+    call output("==================================================================")
+
+    call clock(time, utime)
+  
+    call SYSTEM_CLOCK(counts, count_rate, count_max)
+    starttime = DBLE(counts)/DBLE(count_rate)
+
+    call output("Tracing "//trim(int2string(nlines, '(i6)'))//" lines")
+
+    lcmin = lmin
+    lmin_next = 0d0
+
+    nltot = 0
+    Bl => Blends
+    do iblends = 1, nblends
+      nltot = nltot + Bl%n
+      if (iblends < nblends) Bl => Bl%next
+    end do
+    call output("Total number of wl/velocity points: "//trim(int2string(nltot, '(i7)')))
+
+    Bl => Blends
+    do iblends = 1, nblends
+      if (imagecube) then
+        imcube = 0d0 ! FIXME: in the end I want only one cube, not for each blend, I think that shoulbe be moved outside of the blends loop (like flux)
+        imcube_hit = 0
+      end if
+      flux = 0d0
+
+      nb = Bl%n
+      if (iblends == 1) call output("First line blend ("//trim(int2string(nb, '(i4)'))//" lines)")
+
+      do ib = 1, nb
+        imol_blend(ib) = Bl%L(ib)%imol
+        v_blend(ib) = Bl%v(ib)
       end do
 
-      if (ilam > ilam1) then
-        do k = ilam1 + 1, ilam
-          if (lam_cont(k) > lcmin .and. lam_cont(k) < Bl%lmin) then
-            flux0 = 0d0
-            do i = 1, ngrids
+      LL = Bl%L(1)
+      lam = Bl%lam
+
+      if (lam > lmin .and. lam < lmax) then
+        nl = nl + nb
+
+        ilam = ilam1
+        do while (lam > lam_cont(ilam + 1) .and. ilam < nlam)
+          ilam = ilam + 1
+          if (ilam == nlam) exit
+        end do
+
+        ! CHR: What is this doing ?
+        if (ilam > ilam1) then
+          do k = ilam1 + 1, ilam
+            if (lam_cont(k) > lcmin .and. lam_cont(k) < Bl%lmin) then
+              flux0 = 0d0
+              do i = 1, ngrids
               do j = 1, npoints(i)
                 PP => P(i, j)
                 flux0 = flux0 + PP%flux_cont(k)*PP%A/real(ngrids)
               end do
-            end do
-            flux0 = flux0 + path2star%flux_cont(k)*path2star%A
-            write (20, "(F15.8, 1pE16.8, 1pE16.8, 1pE16.8, 3X, A)") lam_cont(k), &
-              flux0*1e23/(distance*parsec)**2, 0.0, flux0*1e23/(distance*parsec)**2, "continuum"
-          end if
-        end do
-        ilam1 = ilam
-      end if
-      lcmin = Bl%lmax
-
-      call InterpolateLam(lam, ilam)
-      do i = 0, nR
-        do j = 1, nTheta
-          do ilines = 1, Bl%n
-            LL = Bl%L(ilines)
-            fact = clight*hplanck*C(i, j)%N(LL%imol)/(4d0*pi*C(i, j)%line_width(LL%imol)*sqrt(pi))
-            C(i, j)%line_abs(ilines) = fact*(C(i, j)%npop(LL%imol)%N(LL%jlow)*LL%Blu - C(i, j)%npop(LL%imol)%N(LL%jup)*LL%Bul)
-            C(i, j)%line_emis(ilines) = fact*C(i, j)%npop(LL%imol)%N(LL%jup)*LL%Aul
-          end do
-        end do
-      end do
-
-      flux2 = 0d0
-
-			! randomly select a grid. 
-      i = int(ran1(idum)*real(ngrids) + 1)
-!$OMP PARALLEL IF(.true.) &
-!$OMP DEFAULT(NONE) &
-!$OMP PRIVATE(j,PP,iv,vmult,ib0,nb0,gas,ib,imol,flux0,flux4,doit,flux_c,doit_ib,doit_ib0,lam_velo) &
-!$OMP SHARED(i,P,ngrids,npoints,nb,LL,nv,Bl,vresolution,imol_blend,v_blend,flux,ilam) &
-!$OMP SHARED(iblends,flux2,maxblend,lam,lmin_next,imagecube,nvmin,nvmax)
-      allocate (doit_ib0(maxblend))
-      allocate (doit_ib(maxblend))
-      allocate (flux4(nvmin:nvmax))
-
-#ifdef _OPENMP
-      idum = -42 - OMP_GET_THREAD_NUM()     ! setting the seed
-#endif
-
-      flux4(:) = 0d0
-!$OMP DO SCHEDULE(dynamic,1)
-      do j = 1, npoints(i)
-        if (iblends == 1) call tellertje(j, npoints(i))
-        PP => P(i, j)
-        call ContContrPath(PP, flux_c)
-!$OMP ATOMIC
-        flux2 = flux2 + flux_c*PP%A
-        doit = .false.
-        doit_ib0 = .false.
-        do ib = 1, nb
-          if (PP%npopmax(Bl%L(ib)%imol) > Bl%L(ib)%jlow) then
-            doit = .true.
-            doit_ib0(ib) = .true.
-          end if
-        end do
-        if (doit) then
-          do iv = Bl%nvmin, Bl%nvmax
-            lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
-            if (lam_velo > lmin_next) then
-              vmult = 1
-              if (nb > 1) then
-                ib0 = Bl%ib0(iv)
-                nb0 = Bl%nb0(iv)
-                vmult = -1
-                doit_ib(1:nb) = doit_ib0(1:nb)
-                gas = .false.
-                do ib = ib0, ib0 + nb0 - 1
-                  imol = Bl%L(ib)%imol
-                  if (((real(iv) - 0.5d0)*vresolution - Bl%v(ib)) < -PP%vmin(imol) &
-                      .and. ((real(iv) + 0.5d0)*vresolution - Bl%v(ib)) > -PP%vmax(imol)) then
-                    gas = .true.
-                    exit
-                  end if
-                end do
-                if (gas) then
-                  call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
-                else
-                  flux0 = flux_c
-                end if
-                flux4(iv) = flux4(iv) + flux0*PP%A/2d0
-                if (imagecube) call AddImage(iv, i, j, flux0*PP%A/2d0)
-                vmult = 1
-                doit_ib(1:nb) = doit_ib0(1:nb)
-                gas = .false.
-                do ib = ib0, ib0 + nb0 - 1
-                  imol = Bl%L(ib)%imol
-                  if (((real(iv) - 0.5d0)*vresolution - Bl%v(ib)) < PP%vmax(imol) &
-                      .and. ((real(iv) + 0.5d0)*vresolution - Bl%v(ib)) > PP%vmin(imol)) then
-                    gas = .true.
-                    exit
-                  end if
-                end do
-                if (gas) then
-                  call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
-                else
-                  flux0 = flux_c
-                end if
-                flux4(iv) = flux4(iv) + flux0*PP%A/2d0
-                if (imagecube) call AddImage(iv, i, j, flux0*PP%A/2d0)
-
-              else if (((real(iv) + 0.5d0)*vresolution > PP%vmax(LL%imol) .and. &
-                        (real(iv) - 0.5d0)*vresolution > PP%vmax(LL%imol)) &
-                       .or. ((real(iv) + 0.5d0)*vresolution < PP%vmin(LL%imol) .and. &
-                             (real(iv) - 0.5d0)*vresolution < PP%vmin(LL%imol))) then
-                flux0 = flux_c
-                do vmult = -1, 1, 2
-                  flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0
-                  if (imagecube) call AddImage(iv*vmult, i, j, flux0*PP%A/2d0)
-                end do
-              else
-                doit_ib = .true.
-                call TraceFluxLines(PP, flux0, iv, vmult, imol_blend, v_blend, doit_ib, nb, 1)
-                do vmult = -1, 1, 2
-                  flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0
-                  if (imagecube) call AddImage(iv*vmult, i, j, flux0*PP%A/2d0)
-                end do
-              end if
+              end do
+              flux0 = flux0 + path2star%flux_cont(k)*path2star%A
+              write (20, "(F15.8, 1pE16.8, 1pE16.8, 1pE16.8, 3X, A)") lam_cont(k), &
+                flux0*1e23/(distance*parsec)**2, 0.0, flux0*1e23/(distance*parsec)**2, "continuum"
             end if
           end do
-        else
-          flux0 = flux_c
-          flux4(Bl%nvmin:Bl%nvmax) = flux4(Bl%nvmin:Bl%nvmax) + flux0*PP%A
-          if (imagecube) then
-            do iv = Bl%nvmin, Bl%nvmax
-              call AddImage(iv, i, j, flux0*PP%A)
-            end do
-          end if
+          ilam1 = ilam
         end if
-      end do
+        lcmin = Bl%lmax
+
+        call InterpolateLam(lam, ilam)
+        do i = 0, nR
+          do j = 1, nTheta
+            do ilines = 1, Bl%n
+              LL = Bl%L(ilines)
+              fact = clight*hplanck*C(i, j)%N(LL%imol)/(4d0*pi*C(i, j)%line_width(LL%imol)*sqrt(pi))
+              C(i, j)%line_abs(ilines) = fact*(C(i, j)%npop(LL%imol)%N(LL%jlow)*LL%Blu - C(i, j)%npop(LL%imol)%N(LL%jup)*LL%Bul)
+              C(i, j)%line_emis(ilines) = fact*C(i, j)%npop(LL%imol)%N(LL%jup)*LL%Aul
+            end do
+          end do
+        end do
+
+        flux2 = 0d0
+
+			  ! randomly select a grid. 
+        i = int(ran1(idum)*real(ngrids) + 1)
+        if (imagecube) call map_pixels_to_path(i, npoints(i))
+
+        ! FIXME: check parallel implementation for imagecube
+!$OMP PARALLEL IF(.true.) &
+!$OMP DEFAULT(NONE) &
+!$OMP PRIVATE(j,PP,iv,vmult,ib0,nb0,gas,ib,imol,flux0,flux4,doit,flux_c,doit_ib,doit_ib0,lam_velo,callerstr) &
+!$OMP SHARED(i,P,ngrids,npoints,nb,LL,nv,Bl,vresolution,imol_blend,v_blend,flux,ilam) &
+!$OMP SHARED(iblends,flux2,maxblend,lam,lmin_next,imagecube,nvmin,nvmax)
+        allocate (doit_ib0(maxblend))
+        allocate (doit_ib(maxblend))
+        allocate (flux4(nvmin:nvmax))
+
+#ifdef _OPENMP
+        idum = -42 - OMP_GET_THREAD_NUM()     ! setting the seed
+#endif
+
+        flux4(:) = 0d0
+!$OMP DO SCHEDULE(dynamic,1)
+        do j = 1, npoints(i)
+          if (iblends == 1) call tellertje(j, npoints(i))
+          PP => P(i, j)
+
+          !write(88,*) i,j,PP%x/AU,PP%y/AU
+
+          call ContContrPath(PP, flux_c)
+!$OMP ATOMIC
+          flux2 = flux2 + flux_c*PP%A
+          doit = .false.
+          doit_ib0 = .false.
+          do ib = 1, nb
+            if (PP%npopmax(Bl%L(ib)%imol) > Bl%L(ib)%jlow) then
+              doit = .true.
+              doit_ib0(ib) = .true.
+            end if
+          end do
+          if (doit) then
+            !write(*,*) "doit",i,j
+            !write(*,*) Bl%nvmin,Bl%nvmax
+            do iv = Bl%nvmin, Bl%nvmax
+              lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
+              if (lam_velo > lmin_next) then
+                vmult = 1
+                if (nb > 1) then
+                  ib0 = Bl%ib0(iv)
+                  nb0 = Bl%nb0(iv)
+                  vmult = -1
+                  doit_ib(1:nb) = doit_ib0(1:nb)
+                  gas = .false.
+                  do ib = ib0, ib0 + nb0 - 1
+                    imol = Bl%L(ib)%imol
+                    if (((real(iv) - 0.5d0)*vresolution - Bl%v(ib)) < -PP%vmin(imol) &
+                        .and. ((real(iv) + 0.5d0)*vresolution - Bl%v(ib)) > -PP%vmax(imol)) then
+                      gas = .true.
+                      exit
+                    end if
+                  end do
+                  if (gas) then
+                    call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
+                  else
+                    flux0 = flux_c
+                  end if
+                  flux4(iv) = flux4(iv) + flux0*PP%A/2d0
+                  if (imagecube) call AddImage(iv, flux0*PP%A/2d0, PP, vmult, "call nb 1")
+                  vmult = 1
+                  doit_ib(1:nb) = doit_ib0(1:nb)
+                  gas = .false.
+                  do ib = ib0, ib0 + nb0 - 1
+                    imol = Bl%L(ib)%imol
+                    if (((real(iv) - 0.5d0)*vresolution - Bl%v(ib)) < PP%vmax(imol) &
+                        .and. ((real(iv) + 0.5d0)*vresolution - Bl%v(ib)) > PP%vmin(imol)) then
+                      gas = .true.
+                      exit
+                    end if
+                  end do
+                  if (gas) then
+                    call TraceFluxLines(PP, flux0, iv, vmult, imol_blend(ib0), v_blend(ib0), doit_ib(ib0), nb0, ib0)
+                  else
+                    flux0 = flux_c
+                  end if
+                  flux4(iv) = flux4(iv) + flux0*PP%A/2d0
+                  ! FIXME: I think here  times vmult is required, but then it should also be in the line above ? or maybe not
+                  ! or maybe in that case vmult also needs to be ignored for the imagecube
+                  if (imagecube) call AddImage(iv, flux0*PP%A/2d0, PP, vmult, "call nb 2")
+
+                else if (((real(iv) + 0.5d0)*vresolution > PP%vmax(LL%imol) .and. &
+                          (real(iv) - 0.5d0)*vresolution > PP%vmax(LL%imol)) &
+                         .or. ((real(iv) + 0.5d0)*vresolution < PP%vmin(LL%imol) .and. &
+                               (real(iv) - 0.5d0)*vresolution < PP%vmin(LL%imol))) then
+                  flux0 = flux_c
+                  do vmult = -1, 1, 2
+                    flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0
+                    ! Seems to be required here and is done twice
+                    ! FIXME: callerstring is only for debugging, remove it
+                    write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else if", iv, vmult
+                    if (imagecube) then
+                      call AddImage(iv*vmult, flux0*PP%A/2d0, PP, vmult, callerstr)
+                    end if
+                  end do
+                else
+                  doit_ib = .true.
+                  call TraceFluxLines(PP, flux0, iv, vmult, imol_blend, v_blend, doit_ib, nb, 1)
+                  do vmult = -1, 1, 2
+                    flux4(iv*vmult) = flux4(iv*vmult) + flux0*PP%A/2d0
+                    write (callerstr, "(A,' ' ,i5,' ',i2)") "call nb else", iv, vmult
+                    if (imagecube) then
+                      call AddImage(iv*vmult, flux0*PP%A/2d0, PP, vmult, callerstr)
+                    end if
+                  end do
+                end if
+              end if
+            end do
+          else
+            flux0 = flux_c
+            flux4(Bl%nvmin:Bl%nvmax) = flux4(Bl%nvmin:Bl%nvmax) + flux0*PP%A
+            if (imagecube) then
+              do iv = Bl%nvmin, Bl%nvmax
+                call AddImage(iv, flux0*PP%A, PP, 1, "call not doit")
+              end do
+            end if
+          end if
+        end do
 !$OMP END DO
 !$OMP CRITICAL
-      flux(:) = flux(:) + flux4(:)
+        flux(:) = flux(:) + flux4(:)
 !$OMP END CRITICAL
-      deallocate (doit_ib0)
-      deallocate (doit_ib)
-      deallocate (flux4)
+        deallocate (doit_ib0)        
+        deallocate (doit_ib)
+        deallocate (flux4)
 !$OMP FLUSH
 !$OMP END PARALLEL
-      PP => path2star
-      do iv = Bl%nvmin, Bl%nvmax
-        if (nb > 1) then
-          call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
-          flux(iv) = flux(iv) + flux0*PP%A
+        PP => path2star
+        ! FIXME: whatever is done here is not considered for the Images
+        ! I guess it is for the star ... need to check what are the coordinates, then one might just need to calls AddImage again
+        if (.not. allocated(PP%im_ixy)) allocate (PP%im_ixy(2, 1))
+        do iv = Bl%nvmin, Bl%nvmax
+          if (nb > 1) then  ! FIXME: this if seems to be unnecessary
+            call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
+            flux(iv) = flux(iv) + flux0*PP%A
+          else
+            call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
+            flux(iv) = flux(iv) + flux0*PP%A
+          end if
+          if (imagecube) call AddImage(iv, flux0*PP%A, PP, 1, "trace star")
+        end do
+        flux2 = flux2 + flux0*PP%A
+
+        flux1 = 0d0
+        flux3 = 0d0
+
+        f = sqrt((1d0 + real(Bl%nvmin)*vresolution/clight)/(1d0 - real(Bl%nvmin)*vresolution/clight))
+        wl11 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+        ! wl11 can be > 1 if nv*vresolution is wider than the spacing between the continuum points.
+        ! So the continuum grid is too fine, just assume the nearest continuum point then.
+        ! > 1 would mean extrapolation, but in some cases that ends in NaN, limiting it to 1 means, no extrapolation
+        wl11 = min(1d0, max(0d0, wl11))
+        wl21 = 1d0 - wl11
+
+        f = sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
+        wl13 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+        ! see above wl11
+        wl13 = min(1d0, max(0d0, wl13))
+        wl23 = 1d0 - wl13
+
+        flux_l1 = 0d0
+        flux_l2 = 0d0
+        do k = 1, ngrids
+          do j = 1, npoints(k)
+            PP => P(k, j)
+            flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A/real(ngrids)
+            flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A/real(ngrids)
+          end do
+        end do
+        PP => path2star
+
+        flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A
+        flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A
+
+        flux1 = flux_l1**wl11*flux_l2**wl21
+        flux3 = flux_l1**wl13*flux_l2**wl23
+
+        do iv = Bl%nvmin, Bl%nvmax
+          fc = flux1 + (flux3 - flux1)*real(iv - Bl%nvmin)/real(Bl%nvmax - Bl%nvmin)
+          flux(iv) = flux(iv) - flux2 + fc
+          flux_cont(iv) = fc
+        end do
+
+        if (Bl%n == 1) then
+          comment = trim(Mol(Bl%L(1)%imol)%name)//"  up: "//trim(int2string(Bl%L(1)%jup, '(i5)')) &
+                    //"  low: "//trim(int2string(Bl%L(1)%jlow, '(i5)'))
         else
-          call Trace2StarLines(PP, flux0, iv, imol_blend, v_blend, nb)
-          flux(iv) = flux(iv) + flux0*PP%A
+          count = 0
+          do iv = 1, Bl%n
+            count(Bl%L(iv)%imol) = count(Bl%L(iv)%imol) + 1
+          end do
+          comment = "blend of "
+          do iv = 1, nmol
+            if (count(iv) > 0) then
+              comment = trim(comment)//trim(int2string(count(iv), '(i3)'))//" "//trim(Mol(iv)%name)
+            end if
+          end do
+
         end if
-      end do
-      flux2 = flux2 + flux0*PP%A
 
-      flux1 = 0d0
-      flux3 = 0d0
-
-      f = sqrt((1d0 + real(Bl%nvmin)*vresolution/clight)/(1d0 - real(Bl%nvmin)*vresolution/clight))
-      wl11 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-      ! wl11 can be > 1 if nv*vresolution is wider than the spacing between the continuum points.
-      ! So the continuum grid is too fine, just assume the nearest continuum point then.
-      ! > 1 would mean extrapolation, but in some cases that ends in NaN, limiting it to 1 means, no extrapolation
-      wl11 = min(1d0, max(0d0, wl11))
-      wl21 = 1d0 - wl11
-
-      f = sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
-      wl13 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-      ! see above wl11
-      wl13 = min(1d0, max(0d0, wl13))
-      wl23 = 1d0 - wl13
-
-      flux_l1 = 0d0
-      flux_l2 = 0d0
-      do k = 1, ngrids
-        do j = 1, npoints(k)
-          PP => P(k, j)
-          flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A/real(ngrids)
-          flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A/real(ngrids)
-        end do
-      end do
-      PP => path2star
-
-      flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A
-      flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A
-
-      flux1 = flux_l1**wl11*flux_l2**wl21
-      flux3 = flux_l1**wl13*flux_l2**wl23
-
-      do iv = Bl%nvmin, Bl%nvmax
-        fc = flux1 + (flux3 - flux1)*real(iv - Bl%nvmin)/real(Bl%nvmax - Bl%nvmin)
-        flux(iv) = flux(iv) - flux2 + fc
-        flux_cont(iv) = fc
-      end do
-
-      if (Bl%n == 1) then
-        comment = trim(Mol(Bl%L(1)%imol)%name)//"  up: "//trim(int2string(Bl%L(1)%jup, '(i5)')) &
-                  //"  low: "//trim(int2string(Bl%L(1)%jlow, '(i5)'))
-      else
-        count = 0
-        do iv = 1, Bl%n
-          count(Bl%L(iv)%imol) = count(Bl%L(iv)%imol) + 1
-        end do
-        comment = "blend of "
-        do iv = 1, nmol
-          if (count(iv) > 0) then
-            comment = trim(comment)//trim(int2string(count(iv), '(i3)'))//" "//trim(Mol(iv)%name)
+        Bl%F = 0d0
+        lam_velo = lam*sqrt((1d0 + vresolution/clight)/(1d0 - vresolution/clight))
+        dnu = dabs(clight*1d4*(1d0/lam_velo - 1d0/lam))
+        lam_w = 0d0
+        lam_w_min = 1d200
+        lam_w_max = 0d0
+        do iv = Bl%nvmin, Bl%nvmax
+          lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
+          if (lam_velo > lmin_next) then
+            write (20, "(F15.8, 1pE16.8, 1pE16.8, 1pE16.8, 3X, A)") lam_velo, &
+              flux(iv)*1e23/(distance*parsec)**2, &
+              real(iv)*vresolution/1d5, &
+              flux_cont(iv)*1e23/(distance*parsec)**2, &
+              trim(comment)
+            Bl%F = Bl%F + dnu*(flux(iv) - flux_cont(iv))
+            lam_w = lam_w + lam_velo*dnu*(flux(iv) - flux_cont(iv))
+            if (lam_velo < lam_w_min) lam_w_min = lam_velo
+            if (lam_velo > lam_w_max) lam_w_max = lam_velo
           end if
         end do
-      end if
-
-      Bl%F = 0d0
-      lam_velo = lam*sqrt((1d0 + vresolution/clight)/(1d0 - vresolution/clight))
-      dnu = dabs(clight*1d4*(1d0/lam_velo - 1d0/lam))
-      lam_w = 0d0
-      lam_w_min = 1d200
-      lam_w_max = 0d0
-      do iv = Bl%nvmin, Bl%nvmax
-        lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
-        if (lam_velo > lmin_next) then
-          write (20, "(F15.8, 1pE16.8, 1pE16.8, 1pE16.8, 3X, A)") lam_velo, &
-            flux(iv)*1e23/(distance*parsec)**2, &
-            real(iv)*vresolution/1d5, &
-            flux_cont(iv)*1e23/(distance*parsec)**2, &
-            trim(comment)
-          Bl%F = Bl%F + dnu*(flux(iv) - flux_cont(iv))
-          lam_w = lam_w + lam_velo*dnu*(flux(iv) - flux_cont(iv))
-          if (lam_velo < lam_w_min) lam_w_min = lam_velo
-          if (lam_velo > lam_w_max) lam_w_max = lam_velo
+        if (Bl%F /= 0d0) then     ! added PW, June 13, 2022
+          lam_w = lam_w/Bl%F
         end if
-      end do
-      if (Bl%F /= 0d0) then     ! added PW, June 13, 2022
-        lam_w = lam_w/Bl%F
-      end if
-      Bl%F = Bl%F*1d-3/(distance*parsec)**2
-      write (21, *) lam_w, Bl%F, lam_w_min, lam_w_max, trim(comment)
-      lmin_next = max(lmin_next, lam_velo)
+        Bl%F = Bl%F*1d-3/(distance*parsec)**2
+        write (21, *) lam_w, Bl%F, lam_w_min, lam_w_max, trim(comment)
 
-    end if
+        ! has to be here, (i.e. before lmin_next is set, and beofre BL%next is done)
+        if (imagecube) then
+          ! do it similar to the flux output ... find the index where we actuall start (have data)
+          do iv = Bl%nvmin, Bl%nvmax
+            lam_velo_imcube = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
+            if (lam_velo_imcube > lmin_next) exit
+          end do
+          !write(*,*) iv,Bl%nvmax,nvmin,nvmax,lmin_next,lam_velo
+          imcubename = "imcube"//trim(int2string(iblends, '(i0.10)'))//".fits"
+          write (*, *) "Writing image cube to file ", trim(imcubename)
+          !write(*,*) imcube(12,60,-1),imcube(12,42,-1),imcube(12,60,1),imcube(12,42,1)
+          ! currently this is per blend
+          !call writefitsfile(imcubename,imcube*1e23/(distance*parsec)**2,nvmax-nvmin+1,npix)
+          !lam_velo=lam*sqrt((1d0+real(Bl%nvmin)*vresolution/clight)/(1d0-real(Bl%nvmin)*vresolution/clight))
 
-    if (imagecube) then
-      imcubename = "imcube"//trim(int2string(iblends, '(i0.10)'))//".fits.gz"
-      call writefitsfile(imcubename, imcube, nvmax - nvmin + 1, npix)
-    end if
+          ! to avoid nan, assumes that the pixels the should be hit are really hit
+          WHERE (imcube_hit < 1) imcube_hit = 1
 
-    if (iblends < nblends) Bl => Bl%next
+          call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2,nvmax-iv+1,npix,Bl%lam,lam_velo_imcube,.false.)
 
-    call tellertje_time(iblends, nblends, nl, nltot, starttime)
-    !   call tellertje_time(iblends,nblends,iblends,nblends,starttime)
-  end do
+          !imcubename = "imcube_wl"//trim(int2string(iblends, '(i0.10)'))//".fits"
+          !call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2,nvmax-iv+1,npix,Bl%lam,lam_velo_imcube,.true.)
+          !call writefitsfile(imcubename,imcube(:,:,iv:nvmax)*1e23/(distance*parsec)**2/imcube_hit(:,:,iv:nvmax),nvmax-iv+1,npix,Bl%lam,lam_velo_imcube)
 
-  ilam = ilam + 1
-  do while (ilam <= nlam)
-    if (lam_cont(ilam) < lmax) then
-      flux0 = 0d0
-      do j = 1, npoints(i)
-        PP => P(i, j)
-        flux0 = flux0 + PP%flux_cont(ilam)*PP%A
-      end do
-      flux0 = flux0 + path2star%flux_cont(ilam)*path2star%A
-      write (20, "(F15.8, 1pE16.8)") lam_cont(ilam), flux0*1e23/(distance*parsec)**2
-    end if
+          !imcubename = "imcube_hit"//trim(int2string(iblends, '(i0.10)'))//".fits"
+          !call writefitsfile(imcubename,imcube_hit,nvmax-iv+1,npix,npix,Bl%lam,lam_velo_imcube)
+        end if
+
+        lmin_next = max(lmin_next, lam_velo)
+
+      end if ! if(lam>lmin.and.lam<lmax)
+
+      if (iblends < nblends) Bl => Bl%next
+
+      call tellertje_time(iblends, nblends, nl, nltot, starttime)
+!                call tellertje_time(iblends,nblends,iblends,nblends,starttime)
+
+    end do
+
     ilam = ilam + 1
-  end do
+    do while (ilam <= nlam)
+      if (lam_cont(ilam) < lmax) then
+        flux0 = 0d0
+        do j = 1, npoints(i)
+          PP => P(i, j)
+          flux0 = flux0 + PP%flux_cont(ilam)*PP%A
+        end do
+        flux0 = flux0 + path2star%flux_cont(ilam)*path2star%A
+        write (20, "(F15.8, 1pE16.8)") lam_cont(ilam), flux0*1e23/(distance*parsec)**2
+      end if
+      ilam = ilam + 1
+    end do
 
-  close (unit=20)
-  close (unit=21)
+    close (unit=20)
+    close (unit=21)
 
-  !call cpu_time(stoptime)
-  call SYSTEM_CLOCK(counts, count_rate, count_max)
-  stoptime = DBLE(counts)/DBLE(count_rate)
+    !call cpu_time(stoptime)
+    call SYSTEM_CLOCK(counts, count_rate, count_max)
+    stoptime = DBLE(counts)/DBLE(count_rate)
 
-  call output("Time used for the lines:"//trim(dbl2string(stoptime - starttime, '(f8.2)')) &
-              //" s")
-  call output("Time used per line:     "//trim(dbl2string((stoptime - starttime)/real(nlines), '(f8.2)')) &
-              //" s")
-  !   call output("Time used per line:     "//trim(dbl2string((stoptime-starttime)/real(nblends),'(f8.2)'))
-  !   //" s")
-  call clock_write(time, utime, "RaytraceLines:")
+    call output("Time used for the lines:"//trim(dbl2string(stoptime - starttime, '(f8.2)')) &
+                //" s")
+    call output("Time used per line:     "//trim(dbl2string((stoptime - starttime)/real(nlines), '(f8.2)')) &
+                //" s")
+    !   call output("Time used per line:     "//trim(dbl2string((stoptime-starttime)/real(nblends),'(f8.2)'))
+    !   //" s")
+    call clock_write(time, utime, "RaytraceLines:")
 
-  return
-end subroutine RaytraceLines
+    return
+  end subroutine RaytraceLines
 
-subroutine ContContrPath(p0, flux)!
+  subroutine ContContrPath(p0, flux)!
 !   Compute the continuum flux along path p0 at the current line-center
 !   wavelength (set by the last call to InterpolateLam). Integrates the
 !   formal RT solution cell by cell using the pre-interpolated dust opacity
@@ -421,317 +483,532 @@ subroutine ContContrPath(p0, flux)!
 !   exptau_dust(k), S_dust(k) and cont_contr(k) per path element so that
 !   TraceFluxLines can reuse them without recomputing the dust RT.
 ! DOC by Claude
-  use GlobalSetup
-  use Constants
-  implicit none
+    use GlobalSetup
+    use Constants
+    implicit none
+    
+    type(Path),intent(inout) :: p0
+    real(kind=8),intent(out) :: flux
+
+    integer :: i, j, k
+    real(kind=8) :: tau, fact, S, tau_dust, tau_d, tau_tot
   
-  type(Path),intent(inout) :: p0
-  real(kind=8),intent(out) :: flux
+    type(Cell), pointer :: CC
 
-  integer :: i, j, k
-  real(kind=8) :: tau, fact, S, tau_dust, tau_d, tau_tot
-  
-  type(Cell), pointer :: CC
+    fact = 1d0
+    flux = 0d0
+    tau_tot = 0d0
 
-  fact = 1d0
-  flux = 0d0
-  tau_tot = 0d0
+    do k = 1, p0%n
+      i = p0%i(k)
+      j = p0%j(k)
+      if (i > 0 .and. i < nR .and. j > 0) then
+        CC => C(i, j)
+        tau_dust = CC%kext_l
+        ! dust thermal source function
+        S = CC%therm_l*tau_dust
+        ! dust scattering source function
+        S = S + CC%scat_l*tau_dust
 
-  do k = 1, p0%n
-    i = p0%i(k)
-    j = p0%j(k)
-    if (i > 0 .and. i < nR .and. j > 0) then
-      CC => C(i, j)
-      tau_dust = CC%kext_l
-      ! dust thermal source function
-      S = CC%therm_l*tau_dust
-      ! dust scattering source function
-      S = S + CC%scat_l*tau_dust
+        p0%S_dust(k) = S
 
-      p0%S_dust(k) = S
+        tau = tau_dust
+        tau_d = tau*p0%d(k)
+        if (tau_d > 1d-4) then
+          p0%exptau_dust(k) = exp(-tau_d)
+          p0%cont_contr(k) = S*(1d0 - p0%exptau_dust(k))/tau
+        else
+          p0%exptau_dust(k) = 1d0 - tau_d
+          p0%cont_contr(k) = S*p0%d(k)
+        end if
+        flux = flux + p0%cont_contr(k)*fact
 
-      tau = tau_dust
-      tau_d = tau*p0%d(k)
-      if (tau_d > 1d-4) then
-        p0%exptau_dust(k) = exp(-tau_d)
-        p0%cont_contr(k) = S*(1d0 - p0%exptau_dust(k))/tau
-      else
-        p0%exptau_dust(k) = 1d0 - tau_d
-        p0%cont_contr(k) = S*p0%d(k)
+        fact = fact*p0%exptau_dust(k)
+        tau_tot = tau_tot + tau_d
+        if (tau_tot > tau_max) return
       end if
-      flux = flux + p0%cont_contr(k)*fact
+    end do
 
-      fact = fact*p0%exptau_dust(k)
-      tau_tot = tau_tot + tau_d
-      if (tau_tot > tau_max) return
-    end if
-  end do
+    return
+  end subroutine ContContrPath
 
-  return
-end subroutine ContContrPath
+  subroutine TraceFluxLines(p0, flux, ii, vmult, imol_blend, v_blend, doit, nb, ib0)
+    use GlobalSetup
+    use Constants
+    implicit none
+    
+    type(Path),intent(in) :: p0
+    real(kind=8),intent(out) :: flux
+    integer,intent(in) :: ii,vmult,imol_blend(nb)
+    real(kind=8),intent(in) :: v_blend(nb)
+    logical,intent(in) :: doit(nb)
+    integer,intent(in) :: nb, ib0
+    
+    integer :: i, j, k, imol
+    real(kind=8) :: tau, exptau, fact, prof, S, tau_gas, tau_dust, tau_d, tau_tot
+    double precision :: v
+    integer :: jj,ib
+    type(Cell), pointer :: CC
+    logical :: gas
+    real(kind=8) :: rj
 
-subroutine TraceFluxLines(p0, flux, ii, vmult, imol_blend, v_blend, doit, nb, ib0)
-  use GlobalSetup
-  use Constants
-  implicit none
-  
-  type(Path),intent(in) :: p0
-  real(kind=8),intent(out) :: flux
-  integer,intent(in) :: ii,vmult,imol_blend(nb)
-  real(kind=8),intent(in) :: v_blend(nb)
-  logical,intent(in) :: doit(nb)
-  integer,intent(in) :: nb, ib0
-  
-  integer :: i, j, k, imol
-  real(kind=8) :: tau, exptau, fact, prof, S, tau_gas, tau_dust, tau_d, tau_tot
-  double precision :: v
-  integer :: jj,ib
-  type(Cell), pointer :: CC
-  logical :: gas
-  real(kind=8) :: rj
+    fact = 1d0
+    flux = 0d0
+    tau_tot = 0d0
 
-  fact = 1d0
-  flux = 0d0
-  tau_tot = 0d0
+    v = real(ii) + ran1(idum) - 0.5d0
 
-  v = real(ii) + ran1(idum) - 0.5d0
+    do k = 1, p0%n
+      i = p0%i(k)
+      j = p0%j(k)
+      if (i > 0 .and. i < nR .and. j > 0) then
+        CC => C(i, j)
 
-  do k = 1, p0%n
-    i = p0%i(k)
-    j = p0%j(k)
-    if (i > 0 .and. i < nR .and. j > 0) then
-      CC => C(i, j)
+        tau = 0d0
+        S = 0d0
+        gas = .false.
 
-      tau = 0d0
-      S = 0d0
-      gas = .false.
-
-      do ib = 1, nb
-        if (doit(ib)) then
-          imol = imol_blend(ib)
-          rj = ((real(vmult)*p0%v(k) + v_blend(ib))*vres_mult/vresolution - v*vres_mult) &
-               *1d5/CC%line_width(imol)
-          jj = int(rj)
-          if (jj > -nvprofile .and. jj < nvprofile) then
-            if (profile_nz(jj)) then
-              prof = profile(jj)
-              tau_gas = prof*CC%line_abs(ib + ib0 - 1)
-              ! gas source function
-              S = S + prof*CC%line_emis(ib + ib0 - 1)
-              tau = tau + tau_gas
-              gas = .true.
+        do ib = 1, nb
+          if (doit(ib)) then
+            imol = imol_blend(ib)
+            rj = ((real(vmult)*p0%v(k) + v_blend(ib))*vres_mult/vresolution - v*vres_mult) &
+                 *1d5/CC%line_width(imol)
+            jj = int(rj)
+            if (jj > -nvprofile .and. jj < nvprofile) then
+              if (profile_nz(jj)) then
+                prof = profile(jj)
+                tau_gas = prof*CC%line_abs(ib + ib0 - 1)
+                ! gas source function
+                S = S + prof*CC%line_emis(ib + ib0 - 1)
+                tau = tau + tau_gas
+                gas = .true.
+              end if
             end if
+          end if
+        end do
+
+        if (gas) then
+          tau_dust = CC%kext_l
+          S = S + p0%S_dust(k)
+
+          tau = tau + tau_dust
+
+          tau_d = tau*p0%d(k)
+          if (tau_d > 1d-4) then
+            exptau = exp(-tau_d)
+            flux = flux + S*(1d0 - exptau)*fact/tau
+          else
+            exptau = 1d0 - tau_d
+            flux = flux + S*p0%d(k)*fact
+          end if
+        else
+          tau_d = CC%kext_l*p0%d(k)
+          exptau = p0%exptau_dust(k)
+          flux = flux + p0%cont_contr(k)*fact
+        end if
+
+        fact = fact*exptau
+        tau_tot = tau_tot + tau_d
+
+        if (tau_tot > tau_max) return
+      end if
+    end do
+
+    return
+  end subroutine TraceFluxLines
+
+  subroutine Trace2StarLines(p0, flux, ii, imol_blend, v_blend, nb)
+    use GlobalSetup
+    use Constants
+    implicit none  
+    type(Path),intent(in) :: p0
+    real(kind=8),intent(out) :: flux
+    integer,intent(in) :: ii, imol_blend(nb)
+    real(kind=8),intent(in) :: v_blend(nb)
+    integer,intent(in) :: nb
+
+    integer :: i, j, k, imol 
+    real(kind=8) :: tau, prof
+    integer :: ib,jj  
+    type(Cell), pointer :: CC
+
+    tau = 0d0
+
+    do k = 1, p0%n
+      i = p0%i(k)
+      if (i == 0) exit
+      j = p0%j(k)
+      if (i /= 0 .and. i /= nR .and. j /= 0) then
+        CC => C(i, j)
+        tau = tau + CC%kext_l
+
+        do ib = 1, nb
+          imol = imol_blend(ib)
+          jj = int(((p0%v(k) + v_blend(ib))*vres_mult/vresolution - real(ii)*vres_mult)*1d5/CC%line_width(imol))
+          if (jj < -nvprofile) jj = -nvprofile
+          if (jj > nvprofile) jj = nvprofile
+          prof = profile(jj)
+          tau = tau + prof*CC%line_abs(ib)
+        end do
+      end if
+    end do
+
+    flux = Fstar_l*exp(-tau)
+
+    return
+  end subroutine Trace2StarLines
+
+  subroutine DetermineBlends(nv, maxblend, nvmin0, nvmax0)
+    use GlobalSetup
+    use Constants
+    use InOut
+    implicit none
+
+    integer, intent(in) :: nv
+    integer, intent(out) :: maxblend, nvmin0, nvmax0
+    
+    integer :: i, iv, j
+    real(kind=8) :: maxvshift, maxmult, v,f
+    type(Blend), pointer :: Bl
+
+    maxvshift = 2d0*real(nv)*vresolution
+    maxmult = sqrt((1d0 + maxvshift/clight)/(1d0 - maxvshift/clight))
+
+    Bl => Blends
+
+    nblends = 0
+    maxblend = 0
+    nvmin0 = -nv
+    nvmax0 = nv
+
+    do i = 1, nlines
+      Bl%n = 0
+      Bl%nvmin = -nv
+      Bl%nvmax = nv
+      Bl%lam = Lines(i)%lam
+      do j = 1, nlines
+        if ((j > i .and. (Lines(j)%lam/Lines(i)%lam) < maxmult) .or. &
+            (j < i .and. (Lines(i)%lam/Lines(j)%lam) < maxmult) .or. j == i) then
+          Bl%n = Bl%n + 1
+        end if
+      end do
+      allocate (Bl%L(Bl%n))
+      allocate (Bl%v(Bl%n))
+      if (Bl%n > maxblend) maxblend = Bl%n
+      Bl%n = 0
+      do j = 1, nlines
+        if ((j > i .and. (Lines(j)%lam/Lines(i)%lam) < maxmult) .or. &
+            (j < i .and. (Lines(i)%lam/Lines(j)%lam) < maxmult) .or. j == i) then
+          Bl%n = Bl%n + 1
+          Bl%L(Bl%n) = Lines(j)
+          if (i == j) then
+            Bl%v(Bl%n) = 0d0
+          else
+            f = (Lines(j)%lam/Lines(i)%lam)**2
+            Bl%v(Bl%n) = clight*(f - 1d0)/(f + 1d0)
           end if
         end if
       end do
-
-      if (gas) then
-        tau_dust = CC%kext_l
-        S = S + p0%S_dust(k)
-
-        tau = tau + tau_dust
-
-        tau_d = tau*p0%d(k)
-        if (tau_d > 1d-4) then
-          exptau = exp(-tau_d)
-          flux = flux + S*(1d0 - exptau)*fact/tau
-        else
-          exptau = 1d0 - tau_d
-          flux = flux + S*p0%d(k)*fact
-        end if
-      else
-        tau_d = CC%kext_l*p0%d(k)
-        exptau = p0%exptau_dust(k)
-        flux = flux + p0%cont_contr(k)*fact
-      end if
-
-      fact = fact*exptau
-      tau_tot = tau_tot + tau_d
-
-      if (tau_tot > tau_max) return
-    end if
-  end do
-
-  return
-end subroutine TraceFluxLines
-
-subroutine Trace2StarLines(p0, flux, ii, imol_blend, v_blend, nb)
-  use GlobalSetup
-  use Constants
-  implicit none  
-  type(Path),intent(in) :: p0
-  real(kind=8),intent(out) :: flux
-  integer,intent(in) :: ii, imol_blend(nb)
-  real(kind=8),intent(in) :: v_blend(nb)
-  integer,intent(in) :: nb
-
-  integer :: i, j, k, imol 
-  real(kind=8) :: tau, prof
-  integer :: ib,jj  
-  type(Cell), pointer :: CC
-
-  tau = 0d0
-
-  do k = 1, p0%n
-    i = p0%i(k)
-    if (i == 0) exit
-    j = p0%j(k)
-    if (i /= 0 .and. i /= nR .and. j /= 0) then
-      CC => C(i, j)
-      tau = tau + CC%kext_l
-
-      do ib = 1, nb
-        imol = imol_blend(ib)
-        jj = int(((p0%v(k) + v_blend(ib))*vres_mult/vresolution - real(ii)*vres_mult)*1d5/CC%line_width(imol))
-        if (jj < -nvprofile) jj = -nvprofile
-        if (jj > nvprofile) jj = nvprofile
-        prof = profile(jj)
-        tau = tau + prof*CC%line_abs(ib)
+      allocate (Bl%ib0(-nv:nv))
+      allocate (Bl%nb0(-nv:nv))
+      do iv = -nv, nv
+        do j = 1, Bl%n
+          if (real(iv - nv)*vresolution <= Bl%v(j)) exit
+        end do
+        Bl%ib0(iv) = j
+        do j = Bl%n, 1, -1
+          if (real(iv + nv)*vresolution >= Bl%v(j)) exit
+        end do
+        Bl%nb0(iv) = j - Bl%ib0(iv) + 1
       end do
-    end if
-  end do
 
-  flux = Fstar_l*exp(-tau)
+      v = -real(nv)*vresolution
+      Bl%lmin = Bl%L(1)%lam*sqrt((1d0 + v/clight)/(1d0 - v/clight))
+      v = real(nv)*vresolution
+      Bl%lmax = Bl%L(1)%lam*sqrt((1d0 + v/clight)/(1d0 - v/clight))
 
-  return
-end subroutine Trace2StarLines
-
-subroutine DetermineBlends(nv, maxblend, nvmin0, nvmax0)
-  use GlobalSetup
-  use Constants
-  use InOut
-  implicit none
-
-  integer, intent(in) :: nv
-  integer, intent(out) :: maxblend, nvmin0, nvmax0
-  
-  integer :: i, iv, j
-  real(kind=8) :: maxvshift, maxmult, v,f
-  type(Blend), pointer :: Bl
-
-  maxvshift = 2d0*real(nv)*vresolution
-  maxmult = sqrt((1d0 + maxvshift/clight)/(1d0 - maxvshift/clight))
-
-  Bl => Blends
-
-  nblends = 0
-  maxblend = 0
-  nvmin0 = -nv
-  nvmax0 = nv
-
-  do i = 1, nlines
-    Bl%n = 0
-    Bl%nvmin = -nv
-    Bl%nvmax = nv
-    Bl%lam = Lines(i)%lam
-    do j = 1, nlines
-      if ((j > i .and. (Lines(j)%lam/Lines(i)%lam) < maxmult) .or. &
-          (j < i .and. (Lines(i)%lam/Lines(j)%lam) < maxmult) .or. j == i) then
-        Bl%n = Bl%n + 1
-      end if
-    end do
-    allocate (Bl%L(Bl%n))
-    allocate (Bl%v(Bl%n))
-    if (Bl%n > maxblend) maxblend = Bl%n
-    Bl%n = 0
-    do j = 1, nlines
-      if ((j > i .and. (Lines(j)%lam/Lines(i)%lam) < maxmult) .or. &
-          (j < i .and. (Lines(i)%lam/Lines(j)%lam) < maxmult) .or. j == i) then
-        Bl%n = Bl%n + 1
-        Bl%L(Bl%n) = Lines(j)
-        if (i == j) then
-          Bl%v(Bl%n) = 0d0
-        else
-          f = (Lines(j)%lam/Lines(i)%lam)**2
-          Bl%v(Bl%n) = clight*(f - 1d0)/(f + 1d0)
-        end if
-      end if
-    end do
-    allocate (Bl%ib0(-nv:nv))
-    allocate (Bl%nb0(-nv:nv))
-    do iv = -nv, nv
-      do j = 1, Bl%n
-        if (real(iv - nv)*vresolution <= Bl%v(j)) exit
-      end do
-      Bl%ib0(iv) = j
-      do j = Bl%n, 1, -1
-        if (real(iv + nv)*vresolution >= Bl%v(j)) exit
-      end do
-      Bl%nb0(iv) = j - Bl%ib0(iv) + 1
+      allocate (Bl%next)
+      Bl => Bl%next
+      nblends = nblends + 1 ! a bit strange, however, it is indeed the case that each line has its own Blend node
     end do
 
-    v = -real(nv)*vresolution
-    Bl%lmin = Bl%L(1)%lam*sqrt((1d0 + v/clight)/(1d0 - v/clight))
-    v = real(nv)*vresolution
-    Bl%lmax = Bl%L(1)%lam*sqrt((1d0 + v/clight)/(1d0 - v/clight))
+    call output("Number of lines: "//trim(int2string(nlines, '(i7)'))//"  Number of blends: "//trim(int2string(nblends, '(i7)')))  
 
-    allocate (Bl%next)
-    Bl => Bl%next
-    nblends = nblends + 1 ! a bit strange, however, it is indeed the case that each line has its own Blend node
-  end do
-
-  call output("Number of lines: "//trim(int2string(nlines, '(i7)'))//"  Number of blends: "//trim(int2string(nblends, '(i7)')))  
-
-  return
-end subroutine DetermineBlends
+    return
+  end subroutine DetermineBlends
 
 subroutine InterpolateLam(lam0, ilam)
-  use GlobalSetup
-  use Constants
-  implicit none
-  real(kind=8), intent(in) :: lam0
-  integer, intent(in) :: ilam
+    use GlobalSetup
+    use Constants
+    implicit none
+    real(kind=8), intent(in) :: lam0
+    integer, intent(in) :: ilam
 
-  real(kind=8) :: wl1, wl2, w1, w2, x1, x2
-  integer :: i, j
+    real(kind=8) :: wl1, wl2, w1, w2, x1, x2
+    integer :: i, j
 
-  w1 = (lam_cont(ilam + 1) - lam0)/(lam_cont(ilam + 1) - lam_cont(ilam))
-  w2 = 1d0 - w1
-  wl1 = log10(lam_cont(ilam + 1)/lam0)/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-  wl2 = 1d0 - wl1
-  do i = 0, nR
-    do j = 1, nTheta
-      x1 = C(i, j)%kext(ilam)
-      x2 = C(i, j)%kext(ilam + 1)
-      C(i, j)%kext_l = (x1*w1) + (x2*w2)
-      !   x1=C(i,j)%LRF(ilam)*C(i,j)%albedo(ilam)*C(i,j)%kext(ilam)
-      !   x2=C(i,j)%LRF(ilam+1)*C(i,j)%albedo(ilam+1)*C(i,j)%kext(ilam+1)
-      !   C(i,j)%scat_l=(x1*w1+x2*w2)/C(i,j)%kext_l
-      !   x1=BB(ilam,C(i,j)%iT)
-      !   x2=BB(ilam+1,C(i,j)%iT)
-      !   C(i,j)%therm_l=w1*x1+w2*x2
-      !   x1=(1d0-C(i,j)%albedo(ilam))*C(i,j)%kext(ilam)
-      !   x2=(1d0-C(i,j)%albedo(ilam+1))*C(i,j)%kext(ilam+1)
-      !   C(i,j)%therm_l=C(i,j)%therm_l*(w1*x1+w2*x2)/C(i,j)%kext_l
+    w1 = (lam_cont(ilam + 1) - lam0)/(lam_cont(ilam + 1) - lam_cont(ilam))
+    w2 = 1d0 - w1
+    wl1 = log10(lam_cont(ilam + 1)/lam0)/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+    wl2 = 1d0 - wl1
+    do i = 0, nR
+      do j = 1, nTheta
+        x1 = C(i, j)%kext(ilam)
+        x2 = C(i, j)%kext(ilam + 1)
+        C(i, j)%kext_l = (x1*w1) + (x2*w2)
+        !   x1=C(i,j)%LRF(ilam)*C(i,j)%albedo(ilam)*C(i,j)%kext(ilam)
+        !   x2=C(i,j)%LRF(ilam+1)*C(i,j)%albedo(ilam+1)*C(i,j)%kext(ilam+1)
+        !   C(i,j)%scat_l=(x1*w1+x2*w2)/C(i,j)%kext_l
+        !   x1=BB(ilam,C(i,j)%iT)
+        !   x2=BB(ilam+1,C(i,j)%iT)
+        !   C(i,j)%therm_l=w1*x1+w2*x2
+        !   x1=(1d0-C(i,j)%albedo(ilam))*C(i,j)%kext(ilam)
+        !   x2=(1d0-C(i,j)%albedo(ilam+1))*C(i,j)%kext(ilam+1)
+        !   C(i,j)%therm_l=C(i,j)%therm_l*(w1*x1+w2*x2)/C(i,j)%kext_l
 
-      ! Using the source function for now.
-      x1 = C(i, j)%S(ilam)
-      x2 = C(i, j)%S(ilam + 1)
-      C(i, j)%therm_l = (w1*x1 + w2*x2)/2d0
-      C(i, j)%scat_l = (w1*x1 + w2*x2)/2d0
+        ! Using the source function for now.
+        x1 = C(i, j)%S(ilam)
+        x2 = C(i, j)%S(ilam + 1)
+        C(i, j)%therm_l = (w1*x1 + w2*x2)/2d0
+        C(i, j)%scat_l = (w1*x1 + w2*x2)/2d0
+      end do
     end do
-  end do
-  Fstar_l = (Fstar(ilam)**wl1)*(Fstar(ilam + 1)**wl2)
+    Fstar_l = (Fstar(ilam)**wl1)*(Fstar(ilam + 1)**wl2)
 
-  return
-end subroutine InterpolateLam
+    return
+  end subroutine InterpolateLam
+    
+  subroutine DetermineBlendsOld(nv, maxblend, nvmin0, nvmax0)
+    use GlobalSetup
+    use Constants
+    integer ilines, ilines0, i, maxblend, nv, nvmax, iv, nvmin0, nvmax0
+    real(kind=8) maxvshift, maxmult, v
+    type(Blend), pointer :: Bl
 
-subroutine AddImage(iv, i, j, flux0)
-  use GlobalSetup
-  use Constants
-  implicit none
-  real(kind=8) :: flux0, x, y
-  integer :: i, j, iint, ix, iy, iv
+    maxvshift = 2d0*real(nv)*vresolution
+    maxmult = sqrt((1d0 + maxvshift/clight)/(1d0 - maxvshift/clight))
 
-  do iint = 1, nint
-    x = (real(npix)*(x_im(iint, i, j) + Rout)/(2d0*Rout)) + 1d0
-    ix = int(x)
-    y = (real(npix)*(y_im(iint, i, j) + Rout)/(2d0*Rout)) + 1d0
-    iy = int(y)
-    if (ix > 0 .and. ix <= npix .and. iy > 0 .and. iy <= npix) then
-      imcube(ix, iy, iv) = imcube(ix, iy, iv) + flux0/real(nint)
+    Bl => Blends
+
+    ilines = 2
+    ilines0 = 1
+    nblends = 0
+    maxblend = 0
+    nvmin0 = -nv
+    nvmax0 = 0
+    do while (ilines0 <= nlines)
+      Bl%n = 1
+      if (doblend) then
+        do while ((Lines(ilines)%lam/Lines(ilines - 1)%lam) < maxmult .and. ilines <= nlines)
+          Bl%n = Bl%n + 1
+          ilines = ilines + 1
+          if (ilines > nlines) exit
+        end do
+      end if
+      allocate (Bl%L(Bl%n))
+      allocate (Bl%v(Bl%n))
+      if (Bl%n > maxblend) maxblend = Bl%n
+      do i = 1, Bl%n
+        Bl%L(i) = Lines(ilines0 + i - 1)
+        if (i == 1) then
+          Bl%v(i) = 0d0
+        else
+          f = (Bl%L(i)%lam/Bl%L(1)%lam)**2
+          Bl%v(i) = clight*(f - 1d0)/(f + 1d0)
+        end if
+      end do
+      nvmax = nv + int(Bl%v(Bl%n)/vresolution)
+      if (nvmax > nvmax0) nvmax0 = nvmax
+      Bl%nvmin = -nv
+      Bl%nvmax = nvmax
+      allocate (Bl%ib0(-nv:nvmax))
+      allocate (Bl%nb0(-nv:nvmax))
+      do iv = -nv, nvmax
+        do i = 1, Bl%n
+          if (real(iv - nv)*vresolution <= Bl%v(i)) exit
+        end do
+        Bl%ib0(iv) = i
+        do i = Bl%n, 1, -1
+          if (real(iv + nv)*vresolution >= Bl%v(i)) exit
+        end do
+        Bl%nb0(iv) = i - Bl%ib0(iv) + 1
+      end do
+
+      v = -real(nv)*vresolution
+      Bl%lmin = Bl%L(1)%lam*sqrt((1d0 + v/clight)/(1d0 - v/clight))
+      v = real(nvmax)*vresolution
+      Bl%lmax = Bl%L(1)%lam*sqrt((1d0 + v/clight)/(1d0 - v/clight))
+
+      Bl%lam = Bl%L(1)%lam
+
+      ilines0 = ilines
+      ilines = ilines + 1
+      allocate (Bl%next)
+      Bl => Bl%next
+      nblends = nblends + 1
+    end do
+
+    return
+  end subroutine DetermineBlendsOld
+
+  ! ! create a regular pixel coordinate system in the image (fits) plane
+  ! ! with the center pixel being (0,0) x is the horizontal axis and y the vertical one
+  ! ! the x,y coordinates correspond to the center of the grid
+  ! subroutine Imcoords(npix,Rout,im_coord)
+  ! use GlobalSetup
+  ! use Constants
+  ! integer, intent(in) :: npix
+  ! real(kind=8), intent(in) :: Rout
+  ! real(kind=8), intent(inout) :: im_coord(npix,npix) ! should be already allocated
+  ! real(kind=8) :: delpix
+
+  ! delpix=2.d0*Rout*AU/real(npix)
+  ! ! create the coordinates for the pixels
+  ! do i=1,npix ! center coordinates of pixels in cm
+  !         im_coord(:,:)=delpix/2d0+delpix*(i-1)-Rout*AU
+  ! end do
+
+  ! end subroutine im_coords
+
+  subroutine map_pixels_to_path(igrid, npath)
+    use GlobalSetup
+    use Constants
+    implicit none
+    integer, intent(in) :: igrid, npath
+    real(kind=8) :: px(npath), py(npath), dist(npath), im_x, im_y
+    real(kind=8) :: maxx, maxr, maxrxp, maxrxm, pixA
+    type(Path), pointer :: p0
+
+    integer :: i, j, ipath, iminpath, maxnpixpath
+    
+    ! If already allocated this was done already (same grid igrid is used again), no need to map things again
+    if (allocated(P(igrid, 1)%im_ixy)) return
+
+    write (*, *) "Mapping pixels to path igrid,npath", igrid, npath
+
+    ! area of one pixel cm^2
+    pixA = (im_coord(2) - im_coord(1))**2
+
+    ! the paths do not sample the whole image (just the disk)
+    ! In theory this could be different (e.g. if not a disk)
+    !maxr=maxval(abs(P(igrid,:)%y)) ! this should always be the max r, major axis
+    !write(*,*) maxr/AU
+    maxr = R(nr)
+    !maxrxp=maxval(P(igrid,:)%x)
+    !maxrxm=minval(P(igrid,:)%x)
+    !maxr=max(maxrxp,maxrxm)
+
+    P(igrid, :)%im_npix = 0
+    px(1:npath) = P(igrid, 1:npath)%x
+    py(1:npath) = P(igrid, 1:npath)%y
+
+    maxnpixpath = npix*int(npix/10)
+    do ipath = 1, npath
+      ! FIXME: think about how large that can be
+      allocate (P(igrid, ipath)%im_ixy(2, maxnpixpath))
+    end do
+
+    do i = 1, npix
+      im_x = im_coord(i)
+      ! only care about the positive half
+      do j = int(npix/2 + 1), npix
+        im_y = im_coord(j)
+        ! the Path grid does not cover a circel (due to inclination)
+        ! along the x is the minor axis, which has differen Rmax depending on sign
+        if (sqrt((im_x)**2 + (im_y)**2) > maxr) cycle
+        !if ((im_x<0).and.im_x<maxrxm) cycle FIXME: doesn't really work
+        !if ((im_x>0).and.im_x>maxrxp) cycle
+        dist = sqrt((px - im_x)**2 + (py - im_y)**2)
+        ! don't need squareroot
+        iminpath = minloc(dist, dim=1)
+!                        if (i==int(npix/2)) then
+!                                write(*,*) "out: ",i,j,im_x/AU,im_y/AU,dist(iminpath)/AU,iminpath,P(igrid,iminpath)%x/AU,P(igrid,iminpath)%y/AU
+!                        end if
+
+        P(igrid, iminpath)%im_npix = P(igrid, iminpath)%im_npix + 1
+
+        if (P(igrid, iminpath)%im_npix > maxnpixpath) then
+          write (*, *) 'Problem found to many pixels for path'
+          write (*, *) P(igrid, iminpath)%x/AU, P(igrid, iminpath)%y/AU, P(igrid, iminpath)%im_npix
+          stop
+        end if
+        P(igrid, iminpath)%im_ixy(1, P(igrid, iminpath)%im_npix) = i
+        P(igrid, iminpath)%im_ixy(2, P(igrid, iminpath)%im_npix) = j
+      end do
+    end do
+
+    ! now there will be paths with no pixel assigned as in case for Paths being
+    ! close to each other the pixel is only assigned to the closest one
+    ! so simply go through the paths without pixels, and assign the closest one.
+
+    do ipath = 1, npath
+      p0 => P(igrid, ipath)
+      if (p0%im_npix > 0) cycle
+      ! find the closest pixel
+      p0%im_npix = 1
+      p0%im_ixy(1, 1) = minloc(abs(im_coord - p0%x), dim=1)
+      p0%im_ixy(2, 1) = minloc(abs(im_coord - p0%y), dim=1)
+    end do
+
+    ! special treatment for the star
+    ! assume here it is always just one pixel for the moment
+    ! and only needs to be done once
+    if (.not. allocated(path2star%im_ixy)) then
+      allocate (path2star%im_ixy(2, 1))
+
+      path2star%im_npix = 1
+      path2star%im_ixy(1, 1) = minloc(abs(im_coord - path2star%x), dim=1)
+      path2star%im_ixy(2, 1) = minloc(abs(im_coord - path2star%y), dim=1)
+      write (*, *) path2star%x, path2star%y, path2star%im_ixy(:, 1)
     end if
-  end do
 
-  return
-end subroutine AddImage
+    ! some log output and set the correction factor
+
+    p0 => path2star
+    write (99, *) p0%x/AU, p0%y/AU, p0%A/AU/AU, p0%im_ixy(:, 1), p0%im_npix, p0%im_npix*pixA/AU/AU
+
+    do ipath = 1, npath
+      p0 => P(igrid, ipath)
+      write (99, *) p0%x/AU, p0%y/AU, p0%A/AU/AU, p0%im_ixy(:, 1), p0%im_npix, p0%im_npix*pixA/AU/AU
+    end do
+
+  end subroutine map_pixels_to_path
+
+  subroutine AddImage(iv, flux0, p0, vmult, caller) ! FIXME: don't need i, j anymore
+    use GlobalSetup
+    use Constants
+    implicit none
+    real(kind=8), intent(in) :: flux0    
+    integer, intent(in) :: iv
+    integer, intent(in) :: vmult
+    type(Path), intent(in) :: p0
+    character(len=*), intent(in) :: caller        ! just for logging, can be removed
+    integer ix, iy, ipix
+    real(kind=8) :: fluxperpix, pixA
+
+    pixA = (im_coord(2) - im_coord(1))**2
+    ! simply distribute the flux for the path over all pixels equally
+    fluxperpix = flux0/p0%im_npix
+    !fluxperpix=(flux0/p0%A)*pixA
+
+    do ipix = 1, p0%im_npix
+
+      ix = p0%im_ixy(1, ipix)
+      iy = p0%im_ixy(2, ipix)
+
+      ! assume here x and y = 0 at the center of the image
+      if (vmult < 0) then
+        iy = npix - (iy - 1) ! for mirroring the whole thing
+      end if
+
+      ! if (iv==1.or.iv==-1) then
+      !         write(*,*) "Caller: ",trim(caller)
+      !         write(*,*) "AddImage",iv,i,j,flux0,p0%x/AU,p0%y/AU,ix,iy
+      !         !write(*,*) delpix/AU,2.d0*Rout,delpix*real(npix)/AU
+      ! end if
+
+      imcube(iy, ix, iv) = imcube(iy, ix, iv) + fluxperpix ! P%y (Vertical) seems to be along the major axis - make it x
+      imcube_hit(iy, ix, iv) = imcube_hit(iy, ix, iv) + 1
+    end do
+    return
+  end subroutine AddImage

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -489,7 +489,7 @@
     if (imagecube) then
       call output("")
       call output("Writing image cube to file imcube.fits ...")
-      call writefitsfile(imagecube_filename, imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin+dlam_cube/2d0, lmin+dlam_cube/2d0, .true.)
+      call writefitsfile(trim(imagecube_filename), imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin+dlam_cube/2d0, lmin+dlam_cube/2d0, .true.)
       call output("")      
     end if
 

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -83,7 +83,7 @@
         call map_pixels_to_path(i, npoints(i))
       end do
 
-      call output("Image cube has "//trim(int2string(nlam_cube, '(i7)'))//" channels and "//trim(int2string(npix*npix, '(i7)'))//" pixels.")
+      call output("Image cube has "//trim(int2string(nlam_cube, '(i7)'))//" channels (dlam="//trim(dbl2string(dlam_cube, '(F11.4)'))//") and "//trim(int2string(npix*npix, '(i7)'))//" pixels.")
       call output("Image cube size: "//trim(dbl2string(sizeof(imcube)/1.e9, '(F11.4)'))//" GB")
       call clock_write(time, utime, "Prepare image cube: ")
     end if
@@ -489,7 +489,7 @@
     if (imagecube) then
       call output("")
       call output("Writing image cube to file imcube.fits ...")
-      call writefitsfile("imcube.fits", imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin+dlam_cube/2d0, lmin+dlam_cube/2d0, .true.)
+      call writefitsfile(imagecube_filename, imcube*1e23/(distance*parsec)**2, nlam_cube, npix, lmin+dlam_cube/2d0, lmin+dlam_cube/2d0, .true.)
       call output("")      
     end if
 

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -67,7 +67,7 @@
     
     lam = lmin
     ilam1 = 1
-    do while (lam > lam_cont(ilam1 + 1) .and. ilam1 < nlam)
+    do while (lam > lam_cont(ilam1 + 1) .and. ilam1 < nlamCont)
       ilam1 = ilam1 + 1
     end do
 
@@ -136,9 +136,9 @@
         nl = nl + nb
 
         ilam = ilam1
-        do while (lam > lam_cont(ilam + 1) .and. ilam < nlam)
+        do while (lam > lam_cont(ilam + 1) .and. ilam < nlamCont)
           ilam = ilam + 1
-          if (ilam == nlam) exit
+          if (ilam == nlamCont) exit
         end do
 
         ! that writes out continuum only points for the spectrum.
@@ -444,7 +444,7 @@
     end do
 
     ilam = ilam + 1
-    do while (ilam <= nlam)
+    do while (ilam <= nlamCont)
       if (lam_cont(ilam) < lmax) then
         flux0 = 0d0
         do j = 1, npoints(i)

--- a/RaytraceLines.f90
+++ b/RaytraceLines.f90
@@ -398,7 +398,7 @@
             ! not sure why here we do not use vmult treatment
             flux0 = flux_c
             flux4(Bl%nvmin:Bl%nvmax) = flux4(Bl%nvmin:Bl%nvmax) + flux0*PP%A
-            if (imagecube.and..false.) then ! do the vmult treatment for the image cube, important where the flux is
+            if (imagecube) then ! do the vmult treatment for the image cube, important where the flux is
               do vmult = -1, 1, 2
                 do iv = Bl%nvmin, Bl%nvmax
                   lam_velo = lam*sqrt((1d0 + real(iv)*vresolution/clight)/(1d0 - real(iv)*vresolution/clight))
@@ -437,42 +437,42 @@
         flux1 = 0d0
         flux3 = 0d0
 
-        ! f = sqrt((1d0 + real(Bl%nvmin)*vresolution/clight)/(1d0 - real(Bl%nvmin)*vresolution/clight))
-        ! wl11 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-        ! ! wl11 can be > 1 if nv*vresolution is wider than the spacing between the continuum points.
-        ! ! So the continuum grid is too fine, just assume the nearest continuum point then.
-        ! ! > 1 would mean extrapolation, but in some cases that ends in NaN, limiting it to 1 means, no extrapolation
-        ! wl11 = min(1d0, max(0d0, wl11))
-        ! wl21 = 1d0 - wl11
+        f = sqrt((1d0 + real(Bl%nvmin)*vresolution/clight)/(1d0 - real(Bl%nvmin)*vresolution/clight))
+        wl11 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+        ! wl11 can be > 1 if nv*vresolution is wider than the spacing between the continuum points.
+        ! So the continuum grid is too fine, just assume the nearest continuum point then.
+        ! > 1 would mean extrapolation, but in some cases that ends in NaN, limiting it to 1 means, no extrapolation
+        wl11 = min(1d0, max(0d0, wl11))
+        wl21 = 1d0 - wl11
 
-        ! f = sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
-        ! wl13 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
-        ! ! see above wl11
-        ! wl13 = min(1d0, max(0d0, wl13))
-        ! wl23 = 1d0 - wl13
+        f = sqrt((1d0 + real(Bl%nvmax)*vresolution/clight)/(1d0 - real(Bl%nvmax)*vresolution/clight))
+        wl13 = log10(lam_cont(ilam + 1)/(lam*f))/log10(lam_cont(ilam + 1)/lam_cont(ilam))
+        ! see above wl11
+        wl13 = min(1d0, max(0d0, wl13))
+        wl23 = 1d0 - wl13
 
-        ! flux_l1 = 0d0
-        ! flux_l2 = 0d0
-        ! do k = 1, ngrids
-        !   do j = 1, npoints(k)
-        !     PP => P(k, j)
-        !     flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A/real(ngrids)
-        !     flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A/real(ngrids)
-        !   end do
-        ! end do
-        ! PP => path2star
+        flux_l1 = 0d0
+        flux_l2 = 0d0
+        do k = 1, ngrids
+          do j = 1, npoints(k)
+            PP => P(k, j)
+            flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A/real(ngrids)
+            flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A/real(ngrids)
+          end do
+        end do
+        PP => path2star
 
-        ! flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A
-        ! flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A
+        flux_l1 = flux_l1 + PP%flux_cont(ilam)*PP%A
+        flux_l2 = flux_l2 + PP%flux_cont(ilam + 1)*PP%A
 
-        ! flux1 = flux_l1**wl11*flux_l2**wl21
-        ! flux3 = flux_l1**wl13*flux_l2**wl23
+        flux1 = flux_l1**wl11*flux_l2**wl21
+        flux3 = flux_l1**wl13*flux_l2**wl23
 
-        ! do iv = Bl%nvmin, Bl%nvmax
-        !   fc = flux1 + (flux3 - flux1)*real(iv - Bl%nvmin)/real(Bl%nvmax - Bl%nvmin)
-        !   flux(iv) = flux(iv) - flux2 + fc
-        !   flux_cont(iv) = fc
-        ! end do
+        do iv = Bl%nvmin, Bl%nvmax
+          fc = flux1 + (flux3 - flux1)*real(iv - Bl%nvmin)/real(Bl%nvmax - Bl%nvmin)
+          flux(iv) = flux(iv) - flux2 + fc
+          flux_cont(iv) = fc
+        end do
 
         if (Bl%n == 1) then
           comment = trim(Mol(Bl%L(1)%imol)%name)//"  up: "//trim(int2string(Bl%L(1)%jup, '(i5)')) &

--- a/ReadForFLiTs.f90
+++ b/ReadForFLiTs.f90
@@ -46,7 +46,7 @@ subroutine ReadForFLiTs()
   call system_clock(count_rate=count_rate)
 
   ! Use unformatted exchange file if present
-  ! FIXME: this is not used anymore, ProDiMo can only write the fits file now.
+  ! FIXME: this is not used any more, ProDiMo can only write the fits file now.
   inquire(file="ProDiMoForFLiTs.dat", exist=exdat)
 
   !------------------------------------------------------------------------

--- a/ReadForFLiTs.f90
+++ b/ReadForFLiTs.f90
@@ -65,7 +65,7 @@ subroutine ReadForFLiTs()
     read(1) nR
     read(1) nTheta
     read(1) nspec
-    read(1) nlam
+    read(1) nlamCont
   else
     ! Get an unused Logical Unit Number to use to open the FITS file.
     status = 0
@@ -342,7 +342,7 @@ subroutine ReadForFLiTs()
   ! HDU 4 : Lambda
   !------------------------------------------------------------------------------
   if (exdat) then
-    allocate(array_d(nlam,1,1,1))
+    allocate(array_d(nlamCont,1,1,1))
     read(1) array_d
   else
     ! move to next hdu
@@ -354,7 +354,7 @@ subroutine ReadForFLiTs()
     naxis = 1
     ! Check dimensions
     call ftgknj(unit, 'NAXIS', 1, naxis, naxes, nfound, status)
-    nlam = naxes(1)
+    nlamCont = naxes(1)
     do i = naxis+1, 4
       naxes(i) = 1
     enddo
@@ -366,18 +366,18 @@ subroutine ReadForFLiTs()
 
   do i = 0, nR
     do j = 0, nTheta
-      allocate(C(i,j)%kabs(nlam))
-      allocate(C(i,j)%albedo(nlam))
-      allocate(C(i,j)%kext(nlam))
-      allocate(C(i,j)%LRF(nlam))
-      allocate(C(i,j)%S(nlam))
+      allocate(C(i,j)%kabs(nlamCont))
+      allocate(C(i,j)%albedo(nlamCont))
+      allocate(C(i,j)%kext(nlamCont))
+      allocate(C(i,j)%LRF(nlamCont))
+      allocate(C(i,j)%S(nlamCont))
     enddo
   enddo
 
-  allocate(lam_cont(nlam))
-  allocate(Fstar(nlam))
+  allocate(lam_cont(nlamCont))
+  allocate(Fstar(nlamCont))
 
-  do i = 1, nlam
+  do i = 1, nlamCont
     lam_cont(i) = array_d(i,1,1,1)*1d4
   enddo
 
@@ -390,12 +390,12 @@ subroutine ReadForFLiTs()
     call output("Adjusting lambda_min to "//trim(dbl2string(lmin,'(f10.4)')))
   endif
 
-  if (lam_cont(nlam) < lmax) then
-    if (lam_cont(nlam) < lmin) then
+  if (lam_cont(nlamCont) < lmax) then
+    if (lam_cont(nlamCont) < lmin) then
       call output("Wavelength interval not in FLiTs file")
       stop
     endif
-    lmax = lam_cont(nlam)
+    lmax = lam_cont(nlamCont)
     call output("Adjusting lambda_max to "//trim(dbl2string(lmax,'(f10.4)')))
   endif
 
@@ -405,7 +405,7 @@ subroutine ReadForFLiTs()
   ! HDU 5 : Star spectrum
   !------------------------------------------------------------------------------
   if (exdat) then
-    allocate(array_d(nlam,1,1,1))
+    allocate(array_d(nlamCont,1,1,1))
     read(1) array_d
   else
     ! read next hdu
@@ -416,7 +416,7 @@ subroutine ReadForFLiTs()
     endif
   endif
 
-  do i = 1, nlam
+  do i = 1, nlamCont
     Fstar(i) = array_d(i,1,1,1)
   enddo
 
@@ -426,7 +426,7 @@ subroutine ReadForFLiTs()
   ! HDU 6 : ISM spectrum
   !------------------------------------------------------------------------------
   if (exdat) then
-    allocate(array_d(nlam,1,1,1))
+    allocate(array_d(nlamCont,1,1,1))
     read(1) array_d
     deallocate(array_d)
   else
@@ -443,7 +443,7 @@ subroutine ReadForFLiTs()
   ! HDU 7 : Opacites (abs)
   !------------------------------------------------------------------------------
   if (exdat) then
-    allocate(array_d(nlam,nR-1,nTheta-1,1))
+    allocate(array_d(nlamCont,nR-1,nTheta-1,1))
     read(1) array_d
   else
     ! read next hdu
@@ -456,11 +456,11 @@ subroutine ReadForFLiTs()
 
   do i = 1, nR-1
     do j = 2, nTheta
-      do l = 1, nlam
+      do l = 1, nlamCont
         C(i,j)%kabs(l) = array_d(l,i,nTheta+1-j,1)
       enddo
     enddo
-    C(i,1)%kabs(1:nlam) = C(i,2)%kabs(1:nlam)/1d20
+    C(i,1)%kabs(1:nlamCont) = C(i,2)%kabs(1:nlamCont)/1d20
   enddo
 
   deallocate(array_d)
@@ -469,7 +469,7 @@ subroutine ReadForFLiTs()
   ! HDU 8 : Opacites (ext)
   !------------------------------------------------------------------------------
   if (exdat) then
-    allocate(array_d(nlam,nR-1,nTheta-1,1))
+    allocate(array_d(nlamCont,nR-1,nTheta-1,1))
     read(1) array_d
   else
     ! read next hdu
@@ -482,7 +482,7 @@ subroutine ReadForFLiTs()
 
   do i = 1, nR-1
     do j = 2, nTheta
-      do l = 1, nlam
+      do l = 1, nlamCont
         C(i,j)%kext(l) = array_d(l,i,nTheta+1-j,1)
         if (C(i,j)%kext(l) > 1d-150) then
           C(i,j)%albedo(l) = (C(i,j)%kext(l)-C(i,j)%kabs(l))/C(i,j)%kext(l)
@@ -491,8 +491,8 @@ subroutine ReadForFLiTs()
         endif
       enddo
     enddo
-    C(i,1)%kext(1:nlam) = C(i,2)%kext(1:nlam)/1d20
-    C(i,1)%albedo(1:nlam) = C(i,2)%albedo(1:nlam)
+    C(i,1)%kext(1:nlamCont) = C(i,2)%kext(1:nlamCont)/1d20
+    C(i,1)%albedo(1:nlamCont) = C(i,2)%albedo(1:nlamCont)
   enddo
 
   deallocate(array_d)
@@ -501,7 +501,7 @@ subroutine ReadForFLiTs()
   ! HDU 9 : Internal field
   !------------------------------------------------------------------------------
   if (exdat) then
-    allocate(array_d(nlam,nR-1,nTheta-1,1))
+    allocate(array_d(nlamCont,nR-1,nTheta-1,1))
     read(1) array_d
   else
     ! read next hdu
@@ -514,12 +514,12 @@ subroutine ReadForFLiTs()
 
   do i = 1, nR-1
     do j = 2, nTheta
-      do l = 1, nlam
+      do l = 1, nlamCont
         C(i,j)%LRF(l) = array_d(l,i,nTheta+1-j,1)
 !       C(i,j)%LRF(l)=C(i,j)%LRF(l)*lam_cont(l)*1d3*1d-4/clight
       enddo
     enddo
-    C(i,1)%LRF(1:nlam) = C(i,2)%LRF(1:nlam)/1d20
+    C(i,1)%LRF(1:nlamCont) = C(i,2)%LRF(1:nlamCont)/1d20
   enddo
 
   deallocate(array_d)
@@ -528,7 +528,7 @@ subroutine ReadForFLiTs()
   ! HDU 10 : Source function
   !------------------------------------------------------------------------------
   if (exdat) then
-    allocate(array_d(nlam,nR-1,nTheta-1,1))
+    allocate(array_d(nlamCont,nR-1,nTheta-1,1))
     read(1) array_d
   else
     ! read next hdu
@@ -541,11 +541,11 @@ subroutine ReadForFLiTs()
 
   do i = 1, nR-1
     do j = 2, nTheta
-      do l = 1, nlam
+      do l = 1, nlamCont
         C(i,j)%S(l) = exp(array_d(l,i,nTheta+1-j,1))
       enddo
     enddo
-    C(i,1)%S(1:nlam) = C(i,2)%S(1:nlam)/1d20
+    C(i,1)%S(1:nlamCont) = C(i,2)%S(1:nlamCont)/1d20
   enddo
   deallocate(array_d)
 
@@ -730,8 +730,8 @@ subroutine ReadForFLiTs()
   enddo
   i = 0
   do j = 0, nTheta
-    C(i,j)%kext(1:nlam) = 1d-70
-    C(i,j)%kabs(1:nlam) = 1d-70
+    C(i,j)%kext(1:nlamCont) = 1d-70
+    C(i,j)%kabs(1:nlamCont) = 1d-70
     xx = R_av(1)
     zz = xx/tan(theta_av(i,j))
     rr = sqrt(xx*xx+zz*zz)
@@ -740,8 +740,8 @@ subroutine ReadForFLiTs()
   enddo
   i = nR
   do j = 0, nTheta
-    C(i,j)%kext(1:nlam) = 1d-70
-    C(i,j)%kabs(1:nlam) = 1d-70
+    C(i,j)%kext(1:nlamCont) = 1d-70
+    C(i,j)%kabs(1:nlamCont) = 1d-70
     xx = R_av(i)
     zz = xx/tan(theta_av(i,j))
     rr = sqrt(xx*xx+zz*zz)
@@ -751,8 +751,8 @@ subroutine ReadForFLiTs()
 
   j = 0
   do i = 1, nR
-    C(i,j)%kext(1:nlam) = 1d-70
-    C(i,j)%kabs(1:nlam) = 1d-70
+    C(i,j)%kext(1:nlamCont) = 1d-70
+    C(i,j)%kabs(1:nlamCont) = 1d-70
     xx = R_av(i)
     zz = xx/tan(theta_av(i,j))
     rr = sqrt(xx*xx+zz*zz)

--- a/SetupPaths.f90
+++ b/SetupPaths.f90
@@ -209,7 +209,13 @@ subroutine SetupPaths()
       imx = rr*cos(ph)*sin(tt)
       imy = rr*sin(ph)*sin(tt)
       imz = rr*cos(tt)
-      call rotate(imx, imy, imz, 0d0, 1d0, 0d0, -inc*pi/180d0)
+      ! CHR: my guess is that this rotate is done to optimize the path grid
+      ! however, because of this rotate the outer edge of the disk is not sampled on
+      ! the far side of the disk. To be backward compatible still do the rotation if
+      ! imagecube is not used
+      if (.not. imagecube) then
+        call rotate(imx, imy, imz, 0d0, 1d0, 0d0, -inc*pi/180d0)
+      end if
       xy(1, j) = imx
       xy(2, j) = imy
     end do

--- a/SetupPaths.f90
+++ b/SetupPaths.f90
@@ -300,9 +300,9 @@ subroutine SetupPaths()
 
   call output("Number of image gridpoints: "//trim(int2string(k, '(i7)')))
   ! calculate the total area covered by the paths, for checking
-  do  i = 1, ngrids
-    call output("Area of grid"//trim(int2string(i, '(i3)'))//": "//trim(dbl2string(sum(P(i, 1:npoints(i))%A/AU**2), '(F10.3)'))//" AU^2")
-  end do
+  ! do  i = 1, ngrids
+  !   call output("Area of grid"//trim(int2string(i, '(i3)'))//": "//trim(dbl2string(sum(P(i, 1:npoints(i))%A/AU**2), '(F10.3)'))//" AU^2")
+  ! end do
 
   vmax = 0d0
   icount = 0

--- a/SetupPaths.f90
+++ b/SetupPaths.f90
@@ -264,7 +264,8 @@ subroutine SetupPaths()
     do j = 1, npoints(i)
       P(i, j)%x = (xy(1, t_node(1, j)) + xy(1, t_node(2, j)) + xy(1, t_node(3, j)))/3d0
       P(i, j)%y = (xy(2, t_node(1, j)) + xy(2, t_node(2, j)) + xy(2, t_node(3, j)))/3d0
-      !P(i, j)%y = abs(P(i, j)%y)
+      ! this is because we assume the paths are symmetric with respect to the midplane
+      P(i, j)%y = abs(P(i, j)%y)
       r1 = sqrt((xy(1, t_node(1, j)) - xy(1, t_node(2, j)))**2 + (xy(2, t_node(1, j)) - xy(2, t_node(2, j)))**2)
       r2 = sqrt((xy(1, t_node(1, j)) - xy(1, t_node(3, j)))**2 + (xy(2, t_node(1, j)) - xy(2, t_node(3, j)))**2)
       r3 = sqrt((xy(1, t_node(3, j)) - xy(1, t_node(2, j)))**2 + (xy(2, t_node(3, j)) - xy(2, t_node(2, j)))**2)

--- a/SetupPaths.f90
+++ b/SetupPaths.f90
@@ -3,7 +3,7 @@ subroutine SetupPaths()
   use Constants
   use InOut
   implicit none
-  integer :: i, j, k, ir, nRreduce, ilam, imol, nImPhi_max, nPhiMin, nPhiMax, it
+  integer :: i, j, k, ir, nRreduce, ilam, imol, nImPhi_max, nPhiMin, nPhiMax, it,ipoint
   integer, allocatable :: startphi(:)
   double precision :: ct, res_inc, rr, tt, ph
   double precision, allocatable :: imR(:), imPhi(:, :)
@@ -70,8 +70,8 @@ subroutine SetupPaths()
 
   call clock(time, utime)
 
-  do while (nR/nRreduce < 40 .and. nRreduce > 1)
-    nRreduce = nRreduce - 1
+  do while (nR/nrReduce < 40 .and. nrReduce > 1)
+    nrReduce = nrReduce - 1
   end do
 
   ir = 0
@@ -81,15 +81,20 @@ subroutine SetupPaths()
       ir = ir + 3
     end if
   end do
-  do i = 1, nR, nRreduce
+  ! FIXME: what is this? 
+  do i = 1, nR, nrReduce
     ir = ir + 1
     if (cylindrical) then
       ir = ir + 1
     end if
   end do
 
+  ! TODO: the plus 100 looks a bit arbitrary
+  ! FIXME: Somehow it would make more sense to just provide a total number of grid points for the 
+  ! random grid generation
   nImR = ir + int(abs(sin(inc*pi/180d0))*(C(1, nTheta)%v/vresolution)*res_inc/2d0) + (nTheta - 1)*2 + 100
 
+  
   allocate (imR(nImR))
 
   ir = 0
@@ -134,10 +139,12 @@ subroutine SetupPaths()
     imR(ir) = rr*cos(inc*pi/180d0 + (pi/2d0 - theta_av(nR - 1, i)))/ComputeIncFact(imR(ir))
   end do
 
+  write(*,*) "Number of image grid points in R: ", ir,nImR,imR(ir)/AU
   j = (nImR - ir)
   do i = 1, j
     ir = ir + 1
-    imR(ir) = 10d0**(log10(Rstar*Rsun) + log10(R_sphere(nR + 1)/(Rstar*Rsun))*(real(i) - 0.1)/real(j))
+    ! Do not know why there are two lines
+    ! imR(ir) = 10d0**(log10(Rstar*Rsun) + log10(R_sphere(nR + 1)/(Rstar*Rsun))*(real(i) - 0.1)/real(j))
     imR(ir) = 10d0**(log10(R(nR)) + log10(R_sphere(nR + 1)/R(nR))*(real(i) - 0.1)/real(j))
   end do
 
@@ -145,18 +152,31 @@ subroutine SetupPaths()
 
   call sort(imR, nImR)
 
+! FIXME: don't understand the griddgin for R, it is also ignored for the random grid generation
+! but use it for the regular grid, but limit it to the actual size.
+! For the random grid onl nImR is relevant, so keep it 
+
+  if (regular_grid) then
+    nImR = minloc(abs(imR(:) - R(nR))/AU,1)
+  endif
+
   open (unit=20, file='imagegrid.out', RECL=1000)
   do i = 1, nImR
     write (20, *) imR(i)/AU, R_sphere(nR + 1)/AU
   end do
-  close (unit=20)
+  close (unit=20)    
 
+
+  ! This block calculate the number of phi points for each r point
   allocate (nImPhi(nImR))
   allocate (startphi(nImR + 1))
 
   nImPhi_max = 1
   startphi(1) = 1
 
+  ! So points in the radial grid are used to determine the number of phi points for each radius
+  ! however, all that counts later on for the random grid is the total number of points. It is a rather complicated
+  ! way to calculate that.
   npoints_temp = 0
   do i = 1, nImR
     do k = 1, nR - 1
@@ -174,20 +194,24 @@ subroutine SetupPaths()
     if (nImPhi(i) > nImPhi_max) nImPhi_max = nImPhi(i)
     npoints_temp = npoints_temp + nImPhi(i)
   end do
+  
 
-  allocate (imPhi(nImR, nImPhi_max))
+  ! again imPhi, is only needed for the regular grid
+  if (regular_grid) then 
+    allocate (imPhi(nImR, nImPhi_max))
 
-  do i = 1, nImR
-    if (startphi(i) == 1) then
-      do j = 1, nImPhi(i)
-        ImPhi(i, j) = pi*(real(j) - 0.5)/real(nImPhi(i))
-      end do
-    else
-      do j = 1, nImPhi(i)
-        ImPhi(i, j) = pi*real(j - 1)/real(nImPhi(i) - 1)
-      end do
-    end if
-  end do
+    do i = 1, nImR
+      if (startphi(i) == 1) then
+        do j = 1, nImPhi(i)
+          ImPhi(i, j) = pi*(real(j) - 0.5)/real(nImPhi(i))
+        end do
+      else
+        do j = 1, nImPhi(i)
+          ImPhi(i, j) = pi*real(j - 1)/real(nImPhi(i) - 1)
+        end do
+      end if
+    end do
+  end if
 
   allocate (xy(2, npoints_temp))
   allocate (npoints(ngrids))
@@ -195,30 +219,42 @@ subroutine SetupPaths()
   allocate (P(ngrids, matri))
   allocate (t_node(3, matri))
   allocate (t_neighbor(3, matri))
-  k = 0
   do i = 1, ngrids
-    do j = 1, npoints_temp
-      ir = int(ran1(idum)*real(nR))
-      it = int(ran1(idum)*real(nTheta))
-      rr = ran1(idum)
-      rr = sqrt(R(ir)**2*rr + R(ir + 1)**2*(1d0 - rr))
-      tt = ran1(idum)
-      tt = Theta(ir, it)*tt + Theta(ir, it + 1)*(1d0 - tt)
-      tt = acos(tt)
-      ph = ran1(idum)*pi*2d0
-      imx = rr*cos(ph)*sin(tt)
-      imy = rr*sin(ph)*sin(tt)
-      imz = rr*cos(tt)
-      ! CHR: my guess is that this rotate is done to optimize the path grid
-      ! however, because of this rotate the outer edge of the disk is not sampled on
-      ! the far side of the disk. To be backward compatible still do the rotation if
-      ! imagecube is not used
-      if (.not. imagecube) then
-        call rotate(imx, imy, imz, 0d0, 1d0, 0d0, -inc*pi/180d0)
-      end if
-      xy(1, j) = imx
-      xy(2, j) = imy
-    end do
+    ! try a more regular grid, might work better 
+    ! for line cubes
+    if (regular_grid) then
+      ipoint = 0
+      do ir = 1, nImR
+        do j = 1, nImPhi(ir)
+          ipoint = ipoint + 1
+          xy(1, ipoint) = imR(ir) * cos(imPhi(ir, j))
+          xy(2, ipoint) = imR(ir) * sin(imPhi(ir, j))
+        end do
+      end do
+    else
+      do j = 1, npoints_temp
+        ir = int(ran1(idum)*real(nR))
+        it = int(ran1(idum)*real(nTheta))
+        rr = ran1(idum)
+        rr = sqrt(R(ir)**2*rr + R(ir + 1)**2*(1d0 - rr))
+        tt = ran1(idum)
+        tt = Theta(ir, it)*tt + Theta(ir, it + 1)*(1d0 - tt)
+        tt = acos(tt)
+        ph = ran1(idum)*pi*2d0
+        imx = rr*cos(ph)*sin(tt)
+        imy = rr*sin(ph)*sin(tt)
+        imz = rr*cos(tt)
+        ! CHR: my guess is that this rotate is done to optimize the path grid
+        ! however, because of this rotate the outer edge of the disk is not sampled on
+        ! the far side of the disk. To be backward compatible still do the rotation if
+        ! imagecube is not used
+        if (.not. imagecube) then
+          call rotate(imx, imy, imz, 0d0, 1d0, 0d0, -inc*pi/180d0)
+        end if
+        xy(1, j) = imx
+        xy(2, j) = imy
+      end do
+    endif
     matrix(1, 1) = 1d0
     matrix(1, 2) = 0d0
     matrix(2, 1) = 0d0
@@ -227,19 +263,45 @@ subroutine SetupPaths()
     do j = 1, npoints(i)
       P(i, j)%x = (xy(1, t_node(1, j)) + xy(1, t_node(2, j)) + xy(1, t_node(3, j)))/3d0
       P(i, j)%y = (xy(2, t_node(1, j)) + xy(2, t_node(2, j)) + xy(2, t_node(3, j)))/3d0
-      P(i, j)%y = abs(P(i, j)%y)
+      !P(i, j)%y = abs(P(i, j)%y)
       r1 = sqrt((xy(1, t_node(1, j)) - xy(1, t_node(2, j)))**2 + (xy(2, t_node(1, j)) - xy(2, t_node(2, j)))**2)
       r2 = sqrt((xy(1, t_node(1, j)) - xy(1, t_node(3, j)))**2 + (xy(2, t_node(1, j)) - xy(2, t_node(3, j)))**2)
       r3 = sqrt((xy(1, t_node(3, j)) - xy(1, t_node(2, j)))**2 + (xy(2, t_node(3, j)) - xy(2, t_node(2, j)))**2)
       s = (r1 + r2 + r3)/2d0
       P(i, j)%A = sqrt(s*(s - r1)*(s - r2)*(s - r3))
+      ! FIXME: not sure why that is, but for a regular grid I need to double the area
+      if (regular_grid) P(i,j)%A=2.*P(i,j)%A
     end do
+
+    ! Write Delaunay triangulation to file for plotting (e.g. matplotlib triplot).
+    ! File format:
+    !   line 1 : npoints_temp  npoints(i)         (number of vertices, number of triangles)
+    !   next npoints_temp lines : x[AU]  y[AU]     (vertex coordinates)
+    !   next npoints(i) lines   : n0  n1  n2       (0-based triangle node indices)
+    !   next npoints(i) lines   : cx[AU]  cy[AU]   (triangle centroid = P(i,j)%x/y)
+    open(unit=30, file='triangulation_'//trim(int2string(i,'(i2.2)'))//'.txt', status='replace')
+    write(30, '(2(i8,1x))') npoints_temp, npoints(i)
+    do j = 1, npoints_temp
+      write(30, '(2(es16.8,1x))') xy(1,j)/AU, xy(2,j)/AU
+    end do
+    do j = 1, npoints(i)
+      write(30, '(3(i8,1x))') t_node(1,j)-1, t_node(2,j)-1, t_node(3,j)-1
+    end do
+    do j = 1, npoints(i)
+      write(30, '(2(es16.8,1x))') P(i,j)%x/AU, P(i,j)%y/AU
+    end do
+    close(unit=30)
+
     k = k + npoints(i)
   end do
   ncount = k
   k = k/ngrids
 
   call output("Number of image gridpoints: "//trim(int2string(k, '(i7)')))
+  ! calculate the total area covered by the paths, for checking
+  do  i = 1, ngrids
+    call output("Area of grid"//trim(int2string(i, '(i3)'))//": "//trim(dbl2string(sum(P(i, 1:npoints(i))%A/AU**2), '(F10.3)'))//" AU^2")
+  end do
 
   vmax = 0d0
   icount = 0

--- a/SetupPaths.f90
+++ b/SetupPaths.f90
@@ -19,12 +19,19 @@ subroutine SetupPaths()
   double precision :: time, utime
   real(kind=8) :: vmaxgrid
 
+  call clock(time, utime)
+  call output("==================================================================")
+  call output("Setup up the paths for raytracing")
+
   ilam1 = 1
-  ilam2 = nlam
-  do ilam = 1, nlam
+  ilam2 = nlamCont
+  do ilam = 1, nlamCont
     if (lam_cont(ilam) < lmin) ilam1 = ilam
-    if (lam_cont(nlam + 1 - ilam) > lmax) ilam2 = nlam + 1 - ilam
+    if (lam_cont(nlamCont + 1 - ilam) > lmax) ilam2 = nlamCont + 1 - ilam
   end do
+  call output("Considered continuum range: points"//int2string(ilam2-ilam1+1, '(i5)')// &
+              " from "//dbl2string(lam_cont(ilam1), '(F10.3)')// &
+              " to " //dbl2string(lam_cont(ilam2), '(F10.3)')//" micron")
 
   ! increase the resolution in velocity by this factor
 
@@ -65,11 +72,6 @@ subroutine SetupPaths()
     nPhiMax = 270
   end if
 
-  call output("==================================================================")
-  call output("Setup up the paths for raytracing")
-
-  call clock(time, utime)
-
   do while (nR/nrReduce < 40 .and. nrReduce > 1)
     nrReduce = nrReduce - 1
   end do
@@ -93,7 +95,6 @@ subroutine SetupPaths()
   ! FIXME: Somehow it would make more sense to just provide a total number of grid points for the 
   ! random grid generation
   nImR = ir + int(abs(sin(inc*pi/180d0))*(C(1, nTheta)%v/vresolution)*res_inc/2d0) + (nTheta - 1)*2 + 100
-
   
   allocate (imR(nImR))
 

--- a/SetupPaths.f90
+++ b/SetupPaths.f90
@@ -280,18 +280,18 @@ subroutine SetupPaths()
     !   next npoints_temp lines : x[AU]  y[AU]     (vertex coordinates)
     !   next npoints(i) lines   : n0  n1  n2       (0-based triangle node indices)
     !   next npoints(i) lines   : cx[AU]  cy[AU]   (triangle centroid = P(i,j)%x/y)
-    open(unit=30, file='triangulation_'//trim(int2string(i,'(i2.2)'))//'.txt', status='replace')
-    write(30, '(2(i8,1x))') npoints_temp, npoints(i)
-    do j = 1, npoints_temp
-      write(30, '(2(es16.8,1x))') xy(1,j)/AU, xy(2,j)/AU
-    end do
-    do j = 1, npoints(i)
-      write(30, '(3(i8,1x))') t_node(1,j)-1, t_node(2,j)-1, t_node(3,j)-1
-    end do
-    do j = 1, npoints(i)
-      write(30, '(2(es16.8,1x))') P(i,j)%x/AU, P(i,j)%y/AU
-    end do
-    close(unit=30)
+    ! open(unit=30, file='triangulation_'//trim(int2string(i,'(i2.2)'))//'.txt', status='replace')
+    ! write(30, '(2(i8,1x))') npoints_temp, npoints(i)
+    ! do j = 1, npoints_temp
+    !   write(30, '(2(es16.8,1x))') xy(1,j)/AU, xy(2,j)/AU
+    ! end do
+    ! do j = 1, npoints(i)
+    !   write(30, '(3(i8,1x))') t_node(1,j)-1, t_node(2,j)-1, t_node(3,j)-1
+    ! end do
+    ! do j = 1, npoints(i)
+    !   write(30, '(2(es16.8,1x))') P(i,j)%x/AU, P(i,j)%y/AU
+    ! end do
+    ! close(unit=30)
 
     k = k + npoints(i)
   end do

--- a/SetupPaths.f90
+++ b/SetupPaths.f90
@@ -23,15 +23,15 @@ subroutine SetupPaths()
   call output("==================================================================")
   call output("Setup up the paths for raytracing")
 
-  ilam1 = 1
-  ilam2 = nlamCont
+  ilam1Cont = 1
+  ilam2Cont = nlamCont
   do ilam = 1, nlamCont
-    if (lam_cont(ilam) < lmin) ilam1 = ilam
-    if (lam_cont(nlamCont + 1 - ilam) > lmax) ilam2 = nlamCont + 1 - ilam
+    if (lam_cont(ilam) < lmin) ilam1Cont = ilam
+    if (lam_cont(nlamCont + 1 - ilam) > lmax) ilam2Cont = nlamCont + 1 - ilam
   end do
-  call output("Considered continuum range: points"//int2string(ilam2-ilam1+1, '(i5)')// &
-              " from "//dbl2string(lam_cont(ilam1), '(F10.3)')// &
-              " to " //dbl2string(lam_cont(ilam2), '(F10.3)')//" micron")
+  call output("Considered continuum range: points"//int2string(ilam2Cont-ilam1Cont+1, '(i5)')// &
+              " from "//dbl2string(lam_cont(ilam1Cont), '(F10.3)')// &
+              " to " //dbl2string(lam_cont(ilam2Cont), '(F10.3)')//" micron")
 
   ! increase the resolution in velocity by this factor
 
@@ -524,7 +524,7 @@ subroutine tracepath(trac, PP, onlycount)
     trac%y = trac%y + trac%vy*d
     trac%z = trac%z + trac%vz*d
 
-    if (trac%i > 0) taumin = taumin + minval(C(trac%i, trac%j)%kext(ilam1:ilam2))*d
+    if (trac%i > 0) taumin = taumin + minval(C(trac%i, trac%j)%kext(ilam1Cont:ilam2Cont))*d
 
     if (inext > nR) return
     if (inext < 0) return

--- a/SetupPaths.f90
+++ b/SetupPaths.f90
@@ -139,8 +139,7 @@ subroutine SetupPaths()
     imR(ir) = rr*cos(inc*pi/180d0 + (pi/2d0 - theta_av(nR - 1, i)))/ComputeIncFact(imR(ir))
     imR(ir) = rr*cos(inc*pi/180d0 + (pi/2d0 - theta_av(nR - 1, i)))/ComputeIncFact(imR(ir))
   end do
-
-  write(*,*) "Number of image grid points in R: ", ir,nImR,imR(ir)/AU
+  
   j = (nImR - ir)
   do i = 1, j
     ir = ir + 1
@@ -161,11 +160,11 @@ subroutine SetupPaths()
     nImR = minloc(abs(imR(:) - R(nR))/AU,1)
   endif
 
-  open (unit=20, file='imagegrid.out', RECL=1000)
-  do i = 1, nImR
-    write (20, *) imR(i)/AU, R_sphere(nR + 1)/AU
-  end do
-  close (unit=20)    
+  ! open (unit=20, file='imagegrid.out', RECL=1000)
+  ! do i = 1, nImR
+  !   write (20, *) imR(i)/AU, R_sphere(nR + 1)/AU
+  ! end do
+  ! close (unit=20)    
 
 
   ! This block calculate the number of phi points for each r point
@@ -299,7 +298,9 @@ subroutine SetupPaths()
   ncount = k
   k = k/ngrids
 
-  call output("Number of image gridpoints: "//trim(int2string(k, '(i7)')))
+  call output("Number of image gridpoints: "//int2string(k, '(i8)')// &
+              " (ngrids="//int2string(ngrids, '(i2)')//", nR="// &
+              int2string(nImR, '(i4)')//")")
   ! calculate the total area covered by the paths, for checking
   ! do  i = 1, ngrids
   !   call output("Area of grid"//trim(int2string(i, '(i3)'))//": "//trim(dbl2string(sum(P(i, 1:npoints(i))%A/AU**2), '(F10.3)'))//" AU^2")

--- a/SortLines.f90
+++ b/SortLines.f90
@@ -55,9 +55,9 @@ subroutine LineList()
 
   call output("Writing line list")
 
-  open(unit=20, file='LineList.txt', RECL=1000)
+  open(unit=20, file='LineListFLiTs.out', RECL=1000)
   do i = 1, nlines
-    write(20,'(f16.8,"  ",a8,"  ",i8,i8)') Lines(i)%lam, trim(Mol(Lines(i)%imol)%name), Lines(i)%jup, Lines(i)%jlow
+    write(20,'(f16.8,"  ",a10,"  ",i8,i8)') Lines(i)%lam, trim(Mol(Lines(i)%imol)%name), Lines(i)%jup, Lines(i)%jlow
   enddo
   close(unit=20)
 

--- a/Subroutines.f90
+++ b/Subroutines.f90
@@ -112,13 +112,25 @@ end function ran1
 subroutine tellertje(i, n)
   use InOut
   implicit none
-  integer :: i, n, f
+  integer,intent(in) :: i, n 
+  integer :: f,j
+  real(kind=8) :: npoints
+  character(len=20) :: str
+  
+  npoints=min(20.0, real(n,kind=8))
 
-  if (i == 1) call output("....................")
-  f = int(20d0*dble(i)/dble(n))
+  str=""
+  if (i == 1) then 
+    do j = 1, npoints
+      str = trim(str)//"."
+    enddo
+    call output(str)
+  endif
+  
+  f = int(npoints*dble(i)/dble(n))    
 
-  if (20d0*real(i-1)/real(n) < real(f) &
-      .and. 20d0*real(i+1)/real(n) > real(f)) then
+  if (npoints*real(i-1)/real(n) < real(f) &
+      .and. npoints*real(i+1)/real(n) > real(f)) then
     call outputform(".", '(a1,$)')
     flush(6)
   endif

--- a/Subroutines.f90
+++ b/Subroutines.f90
@@ -121,7 +121,7 @@ subroutine tellertje(i, n)
 
   str=""
   if (i == 1) then 
-    do j = 1, npoints
+    do j = 1, int(npoints)
       str = trim(str)//"."
     enddo
     call output(str)

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -1,27 +1,27 @@
-subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
+subroutine write_imcube(filename, specunitwl)
   ! Write the image cube im, to a fits files with name filename.
   !
   ! Please note the flux values are stored in single precision to save disks space.  
   !
   ! TODO: activate the option for spectral units in frequency, but currently only wavelength is supported.
   !
-  use GlobalSetup, only: distance, vresolution, dlam_cube,inc,delpix
+  use GlobalSetup, only: distance, vresolution,nlam_cube,npix,dlam_cube,inc,delpix,imcube,lam_cube
   use Constants, only: pi, clight, parsec, AU
   use InOut
   IMPLICIT NONE
   character(len=*),intent(in) :: filename
-  integer, intent(in) :: nv, n
-  double precision, intent(in) :: restlam, reflam
   logical, intent(in) :: specunitwl
-  real centerpix
-  double precision im(n, n, nv)
+  real(kind=8) :: centerpix
+
   real(kind=8) :: degree, spixdegree
   character(len=500) :: VersionGIT
 
-  integer status, unit, blocksize, bitpix, naxis, naxes(3)
-  integer group, fpixel, nelements
-  logical simple, extend, truefalse
-  real refFrqHz, delHz, restFrqHz, delwl
+  integer status, unit, blocksize, bitpix, naxis
+  integer group
+  integer :: naxes(3)
+  integer(kind=8) :: nelements, fpixel
+  logical truefalse
+  real(kind=8) :: refFrqHz, delHz, restFrqHz,reflam
 
   inquire (file=filename, exist=truefalse)
   if (truefalse) then
@@ -38,21 +38,19 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   call ftinit(unit, filename, blocksize, status)
 
   ! initialize parameters about the FITS image (IMDIM x IMDIM 64-bit reals)
-  simple = .true.
   bitpix = -32 ! single precision should be enough
-  naxes(1) = n
-  naxes(2) = n
-  if (nv > 1) then
+  naxes(1) = npix
+  naxes(2) = npix
+  if (nlam_cube > 1) then
     naxis = 3
-    naxes(3) = nv
+    naxes(3) = nlam_cube
   else
     naxis = 2
     naxes(3) = 1
   end if
-  extend = .true.
 
   ! write the required header keywords
-  call ftphpr(unit, simple, bitpix, naxis, naxes, 0, 1, extend, status)
+  call FTPHPS(unit,bitpix, naxis, naxes, status)  
 
   degree = pi/180.0           ! one degree in rad
 
@@ -61,7 +59,7 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   spixdegree = delpix/(distance*parsec)/degree
 
   ! put some coordinate system
-  centerpix = n/2 + 1.0 ! FIXME: requires odd number of pixels
+  centerpix = npix/2 + 1.0 ! require odd number of pixels
   call ftpkys(unit, 'ctype1', 'RA---SIN', '', status)
   call ftpkys(unit, 'cunit1', 'deg     ', '', status)
   call ftpkyd(unit, 'crval1', 68.0, 12, 'dummy value', status)
@@ -77,13 +75,8 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   call ftpkyd(unit, 'crpix2', centerpix, 12, 'center pixel', status)
   call ftpkys(unit, 'RADESYS', 'ICRS', '', status)
 
-  restFrqHz = clight/(restlam/1.e4)
-  refFrqHz = clight/(reflam/1.e4)
-
-  delHz = -restFrqHz*vresolution/clight
-  delwl = restlam*vresolution/clight
-  !write(*,*) reflam,restlam,vresolution,restFrqHz,refFrqHz,delHz,delwl
-
+  reflam=lam_cube(1) ! this is the reference wavelength, which is the first channel in the cube. This is used for the spectral axis keywords in the FITS header.
+    
   if (specunitwl) then
     call ftpkys(unit, 'CTYPE3', 'WAVE', '[micron]', status)
     call ftpkys(unit, 'cunit3', 'um      ', '', status)
@@ -92,6 +85,10 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
     call ftpkyd(unit, 'crpix3', 1.0, 12, 'Reference channel', status)
   else
     ! FIXME: not really supported at the momement
+    restFrqHz = clight/(reflam/1.e4)
+    refFrqHz = clight/(reflam/1.e4)
+    delHz = -restFrqHz*vresolution/clight
+
     !----- spectral axis -----
     ! Frequency/Spectral coordinate
     ! the first channel (velo) point is the reference
@@ -109,20 +106,22 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
     call ftpkyd(unit, 'RESTFREQ', restFrqHz, 12, '', status) ! this means first spectral axis point would give v=0    
   end if
 
-  if (status /= 0) then
-    call output("Error writing header to FITS file: "//trim(filename)//". Status: "//int2string(status))
-  end if
-  
+  call ftpkys(unit, 'BUNIT', 'Jy/pixel', 'Flux density per pixel', status)  
   call ftpkyd(unit, 'incl', inc, 7, 'Inclination [deg]', status)
   call ftpkyd(unit, 'dist', distance, 7, 'Distance [pc]', status)
   call ftpkys(unit, 'origin', 'FLiTs/ProDiMo model', '', status)
   call ftpkys(unit, 'version', trim(VersionGIT()), 'FLiTs version', status)
   
+  if (status /= 0) then
+    call output("Error writing header to FITS file: "//trim(filename)//". Status: "//int2string(status))
+  end if
+
   ! write the array to the FITS file
   group = 1
-  fpixel = 1
-  nelements = naxes(1)*naxes(2)*naxes(3)
-  call ftpprd(unit, group, fpixel, nelements, im, status)
+  fpixel = 1_8
+  nelements = int(naxes(1),kind=8)*int(naxes(2),kind=8)*int(naxes(3),kind=8)
+  ! write and convert to proper units
+  call ftppre(unit, group, fpixel, nelements, imcube(:,:,:)*real(1e23/(distance*parsec)**2,kind=4), status)
   if (status /= 0) then
     call output("Error writing data to FITS file: "//trim(filename)//". Status: "//int2string(status))    
   end if
@@ -132,4 +131,4 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   call ftfiou(unit, status)
 
   return
-end subroutine writefitsfile
+end subroutine write_imcube

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -53,10 +53,13 @@ subroutine write_imcube(filename, specunitwl)
   call FTPHPS(unit,bitpix, naxis, naxes, status)  
 
   degree = pi/180.0           ! one degree in rad
-
   !----- constant size of all pixels in [sr] -----
   ! dist is from Parameter.in (is already converted to cm)  
   spixdegree = delpix/(distance*parsec)/degree
+  ! this is the reference wavelength, which is the first channel in the cube. This is used for the spectral axis keywords in the FITS header.
+  reflam=lam_cube(1) 
+  ! also put the restFrquency in Hz, for reference
+  restFrqHz = clight/(reflam/1.e4)
 
   ! put some coordinate system
   centerpix = npix/2 + 1.0 ! require odd number of pixels
@@ -74,9 +77,7 @@ subroutine write_imcube(filename, specunitwl)
   call ftpkyd(unit, 'crota2', 0.0, 12, '', status)
   call ftpkyd(unit, 'crpix2', centerpix, 12, 'center pixel', status)
   call ftpkys(unit, 'RADESYS', 'ICRS', '', status)
-
-  reflam=lam_cube(1) ! this is the reference wavelength, which is the first channel in the cube. This is used for the spectral axis keywords in the FITS header.
-    
+      
   if (specunitwl) then
     call ftpkys(unit, 'CTYPE3', 'WAVE', '[micron]', status)
     call ftpkys(unit, 'cunit3', 'um      ', '', status)
@@ -85,10 +86,8 @@ subroutine write_imcube(filename, specunitwl)
     call ftpkyd(unit, 'crpix3', 1.0, 12, 'Reference channel', status)
   else
     ! FIXME: not really supported at the momement
-    restFrqHz = clight/(reflam/1.e4)
     refFrqHz = clight/(reflam/1.e4)
     delHz = -restFrqHz*vresolution/clight
-
     !----- spectral axis -----
     ! Frequency/Spectral coordinate
     ! the first channel (velo) point is the reference
@@ -97,16 +96,14 @@ subroutine write_imcube(filename, specunitwl)
     call ftpkyd(unit, 'crval3', refFrqHz, 12, 'Reference FREQ', status)
     call ftpkyd(unit, 'CDELT3', delHz, 12, 'd_Hz (channel width)', status)
     call ftpkyd(unit, 'crpix3', 1.0, 12, 'Reference channel', status)
-    ! this is for velocity spectral units.
-    call ftpkys(unit, 'SPECSYS', 'LSRK', 'Spectral reference frame', status)
-    call ftpkyj(unit, 'VELREF', 257, 'Radio velocity in CASA', status)
-    call ftpkys(unit, 'timesys', 'UTC     ', '', status)
-    call ftpkys(unit, 'cellscal', 'CONSTANT', '', status)
-    ! Restfrequency
-    call ftpkyd(unit, 'RESTFREQ', restFrqHz, 12, '', status) ! this means first spectral axis point would give v=0    
   end if
 
+  call ftpkys(unit, 'SPECSYS', 'LSRK', 'Spectral reference frame', status)
+  call ftpkys(unit, 'timesys', 'UTC     ', '', status)  
   call ftpkys(unit, 'BUNIT', 'Jy/pixel', 'Flux density per pixel', status)  
+  ! Restfrequency for the first spectral channel 
+  call ftpkyd(unit, 'RESTFREQ', restFrqHz, 12, '', status) 
+
   call ftpkyd(unit, 'incl', inc, 7, 'Inclination [deg]', status)
   call ftpkyd(unit, 'dist', distance, 7, 'Distance [pc]', status)
   call ftpkys(unit, 'origin', 'FLiTs/ProDiMo model', '', status)

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -3,7 +3,7 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   use Constants, only: pi, clight, parsec, AU
   use InOut
   IMPLICIT NONE
-  character(len=500) filename
+  character(len=500),intent(in) :: filename
   integer, intent(in) :: nv, n
   double precision, intent(in) :: restlam, reflam
   logical, intent(in) :: specunitwl
@@ -22,13 +22,7 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
     open (unit=90, file=filename)
     close (unit=90, status='delete')
   end if
-
-  status = 0
-  ! Get an unused Logical Unit Number to use to create the FITS file
-  call ftgiou(unit, status)
-  ! create the new empty FITS file
-  blocksize = 1
-  call ftinit(unit, filename, blocksize, status)
+  
   status = 0
   ! Get an unused Logical Unit Number to use to create the FITS file
   call ftgiou(unit, status)
@@ -108,9 +102,13 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
     call ftpkys(unit, 'timesys', 'UTC     ', '', status)
     call ftpkys(unit, 'cellscal', 'CONSTANT', '', status)
     ! Restfrequency
-    call ftpkyd(unit, 'RESTFREQ', restFrqHz, 12, '', status) ! this means first spectral axis point would give v=0
+    call ftpkyd(unit, 'RESTFREQ', restFrqHz, 12, '', status) ! this means first spectral axis point would give v=0    
   end if
 
+  if (status /= 0) then
+    call output("Error writing header to FITS file: "//trim(filename)//". Status: "//int2string(status))
+  end if
+  
   call ftpkys(unit, 'origin', 'FLiTs/ProDiMo model', '', status)
 
   ! write the array to the FITS file
@@ -118,6 +116,9 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   fpixel = 1
   nelements = naxes(1)*naxes(2)*naxes(3)
   call ftpprd(unit, group, fpixel, nelements, im, status)
+  if (status /= 0) then
+    call output("Error writing data to FITS file: "//trim(filename)//". Status: "//int2string(status))    
+  end if
 
   ! close the file and free the unit number
   call ftclos(unit, status)

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -36,7 +36,7 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   blocksize = 1
   call ftinit(unit, filename, blocksize, status)
 
-!     initialize parameters about the FITS image (IMDIM x IMDIM 64-bit reals)
+  ! initialize parameters about the FITS image (IMDIM x IMDIM 64-bit reals)
   simple = .true.
   !bitpix=-64
   bitpix = -32 ! single precision should be enough
@@ -51,7 +51,7 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   end if
   extend = .true.
 
-!     write the required header keywords
+  ! write the required header keywords
   call ftphpr(unit, simple, bitpix, naxis, naxes, 0, 1, extend, status)
 
   degree = pi/180.0           ! one degree in rad
@@ -116,7 +116,7 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   ! write the array to the FITS file
   group = 1
   fpixel = 1
-  nelements = naxes(1)*naxes(2)*naxes(3)  
+  nelements = naxes(1)*naxes(2)*naxes(3)
   call ftpprd(unit, group, fpixel, nelements, im, status)
 
   ! close the file and free the unit number

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -1,13 +1,20 @@
-subroutine writefitsfile(filename, im, nlam, n)
+subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
+  use GlobalSetup, only: Rout, distance, lmin, vresolution
+  use Constants, only: pi, clight, parsec, AU
   use InOut
-  implicit none
-  character(len=500) :: filename
-  integer :: n, nlam
-  real(kind=8) :: im(n, n, nlam)
+  IMPLICIT NONE
+  character(len=500) filename
+  integer, intent(in) :: nv, n
+  double precision, intent(in) :: restlam, reflam
+  logical, intent(in) :: specunitwl
+  real centerpix
+  double precision im(n, n, nv)
+  double precision degree, delpix, spixdegree
 
-  integer :: status, unit, blocksize, bitpix, naxis, naxes(3)
-  integer :: group, fpixel, nelements
-  logical :: simple, extend, truefalse
+  integer status, unit, blocksize, bitpix, naxis, naxes(3)
+  integer i, j, group, fpixel, nelements
+  logical simple, extend, truefalse
+  real refFrqHz, delHz, restFrqHz, delwl
 
   inquire (file=filename, exist=truefalse)
   if (truefalse) then
@@ -22,28 +29,94 @@ subroutine writefitsfile(filename, im, nlam, n)
   ! create the new empty FITS file
   blocksize = 1
   call ftinit(unit, filename, blocksize, status)
+  status = 0
+  ! Get an unused Logical Unit Number to use to create the FITS file
+  call ftgiou(unit, status)
+  ! create the new empty FITS file
+  blocksize = 1
+  call ftinit(unit, filename, blocksize, status)
 
-  ! initialize parameters about the FITS image (IMDIM x IMDIM 64-bit reals)
+!     initialize parameters about the FITS image (IMDIM x IMDIM 64-bit reals)
   simple = .true.
-  bitpix = -64
+  !bitpix=-64
+  bitpix = -32 ! single precision should be enough
   naxes(1) = n
   naxes(2) = n
-  if (nlam > 1) then
+  if (nv > 1) then
     naxis = 3
-    naxes(3) = nlam
+    naxes(3) = nv
   else
     naxis = 2
     naxes(3) = 1
   end if
   extend = .true.
 
-  ! write the required header keywords
+!     write the required header keywords
   call ftphpr(unit, simple, bitpix, naxis, naxes, 0, 1, extend, status)
+
+  degree = pi/180.0           ! one degree in rad
+
+  !----- constant size of all pixels in [sr] -----
+  ! dist is from Parameter.in (is already converted to cm)
+  delpix = 2.d0*Rout*AU/real(n)        ! this is in cm
+  spixdegree = delpix/(distance*parsec)/degree
+
+  ! put some coordinate system
+  centerpix = n/2 + 1.0 ! FIXME: requires odd number of pixels
+  call ftpkys(unit, 'ctype1', 'RA---SIN', '', status)
+  call ftpkys(unit, 'cunit1', 'deg     ', '', status)
+  call ftpkyd(unit, 'crval1', 68.0, 12, 'dummy value', status)
+  call ftpkyd(unit, 'cdelt1', spixdegree, 12, '', status)
+  call ftpkyd(unit, 'crota1', 0.0, 12, '', status)
+  call ftpkyd(unit, 'crpix1', centerpix, 12, 'center pixel', status)
+
+  call ftpkys(unit, 'ctype2', 'DEC--SIN', '', status)
+  call ftpkys(unit, 'cunit2', 'deg     ', '', status)
+  call ftpkyd(unit, 'crval2', 24.0, 12, 'dummy value', status)
+  call ftpkyd(unit, 'cdelt2', spixdegree, 12, '', status)
+  call ftpkyd(unit, 'crota2', 0.0, 12, '', status)
+  call ftpkyd(unit, 'crpix2', centerpix, 12, 'center pixel', status)
+  call ftpkys(unit, 'RADESYS', 'ICRS', '', status)
+
+  ! the the first point (which should be lmin as the reference
+
+  restFrqHz = clight/(restlam/1.e4)
+  refFrqHz = clight/(reflam/1.e4)
+
+  delHz = -restFrqHz*vresolution/clight
+  delwl = restlam*vresolution/clight
+  !write(*,*) reflam,restlam,vresolution,restFrqHz,refFrqHz,delHz,delwl
+
+  if (specunitwl) then
+    call ftpkys(unit, 'CTYPE3', 'WAVE', '[micron]', status)
+    call ftpkys(unit, 'cunit3', 'um      ', '', status)
+    call ftpkyd(unit, 'crval3', reflam, 12, 'Reference wl', status)
+    call ftpkyd(unit, 'CDELT3', delwl, 12, 'd_wl (channel width)', status)
+    call ftpkyd(unit, 'crpix3', 1.0, 12, 'Reference channel', status)
+  else
+    !----- spectral axis -----
+    ! Frequency/Spectral coordinate
+    ! the first channel (velo) point is the reference
+    call ftpkys(unit, 'CTYPE3', 'FREQ', '[Hz]', status)
+    call ftpkys(unit, 'cunit3', 'Hz      ', '', status)
+    call ftpkyd(unit, 'crval3', refFrqHz, 12, 'Reference FREQ', status)
+    call ftpkyd(unit, 'CDELT3', delHz, 12, 'd_Hz (channel width)', status)
+    call ftpkyd(unit, 'crpix3', 1.0, 12, 'Reference channel', status)
+    ! this is for velocity spectral units.
+    call ftpkys(unit, 'SPECSYS', 'LSRK', 'Spectral reference frame', status)
+    call ftpkyj(unit, 'VELREF', 257, 'Radio velocity in CASA', status)
+    call ftpkys(unit, 'timesys', 'UTC     ', '', status)
+    call ftpkys(unit, 'cellscal', 'CONSTANT', '', status)
+    ! Restfrequency
+    call ftpkyd(unit, 'RESTFREQ', restFrqHz, 12, '', status) ! this means first spectral axis point would give v=0
+  end if
+
+  call ftpkys(unit, 'origin', 'FLiTs/ProDiMo model', '', status)
 
   ! write the array to the FITS file
   group = 1
   fpixel = 1
-  nelements = naxes(1)*naxes(2)*naxes(3)
+  nelements = naxes(1)*naxes(2)*naxes(3)  
   call ftpprd(unit, group, fpixel, nelements, im, status)
 
   ! close the file and free the unit number
@@ -52,4 +125,3 @@ subroutine writefitsfile(filename, im, nlam, n)
 
   return
 end subroutine writefitsfile
-

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -1,5 +1,11 @@
 subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
-  use GlobalSetup, only: Rout, distance, lmin, vresolution, dlam_cube
+  ! Write the image cube im, to a fits files with name filename.
+  !
+  ! Please note the flux values are stored in single precision to save disks space.  
+  !
+  ! TODO: activate the option for spectral units in frequency, but currently only wavelength is supported.
+  !
+  use GlobalSetup, only: distance, vresolution, dlam_cube,inc,delpix
   use Constants, only: pi, clight, parsec, AU
   use InOut
   IMPLICIT NONE
@@ -9,10 +15,11 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   logical, intent(in) :: specunitwl
   real centerpix
   double precision im(n, n, nv)
-  double precision degree, delpix, spixdegree
+  real(kind=8) :: degree, spixdegree
+  character(len=500) :: VersionGIT
 
   integer status, unit, blocksize, bitpix, naxis, naxes(3)
-  integer i, j, group, fpixel, nelements
+  integer group, fpixel, nelements
   logical simple, extend, truefalse
   real refFrqHz, delHz, restFrqHz, delwl
 
@@ -32,7 +39,6 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
 
   ! initialize parameters about the FITS image (IMDIM x IMDIM 64-bit reals)
   simple = .true.
-  !bitpix=-64
   bitpix = -32 ! single precision should be enough
   naxes(1) = n
   naxes(2) = n
@@ -51,8 +57,7 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   degree = pi/180.0           ! one degree in rad
 
   !----- constant size of all pixels in [sr] -----
-  ! dist is from Parameter.in (is already converted to cm)
-  delpix = 2.d0*Rout*AU/real(n)        ! this is in cm
+  ! dist is from Parameter.in (is already converted to cm)  
   spixdegree = delpix/(distance*parsec)/degree
 
   ! put some coordinate system
@@ -71,8 +76,6 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   call ftpkyd(unit, 'crota2', 0.0, 12, '', status)
   call ftpkyd(unit, 'crpix2', centerpix, 12, 'center pixel', status)
   call ftpkys(unit, 'RADESYS', 'ICRS', '', status)
-
-  ! the the first point (which should be lmin as the reference
 
   restFrqHz = clight/(restlam/1.e4)
   refFrqHz = clight/(reflam/1.e4)
@@ -111,6 +114,9 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   end if
   
   call ftpkys(unit, 'origin', 'FLiTs/ProDiMo model', '', status)
+  call ftpkys(unit, 'version', trim(VersionGIT()), 'FLiTs version', status)
+  call ftpkyd(unit, 'incl', inc, 7, 'Inclination', status)
+  call ftpkyd(unit, 'dist', distance, 7, 'Distance', status)
 
   ! write the array to the FITS file
   group = 1

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -113,11 +113,11 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
     call output("Error writing header to FITS file: "//trim(filename)//". Status: "//int2string(status))
   end if
   
+  call ftpkyd(unit, 'incl', inc, 7, 'Inclination [deg]', status)
+  call ftpkyd(unit, 'dist', distance, 7, 'Distance [pc]', status)
   call ftpkys(unit, 'origin', 'FLiTs/ProDiMo model', '', status)
   call ftpkys(unit, 'version', trim(VersionGIT()), 'FLiTs version', status)
-  call ftpkyd(unit, 'incl', inc, 7, 'Inclination', status)
-  call ftpkyd(unit, 'dist', distance, 7, 'Distance', status)
-
+  
   ! write the array to the FITS file
   group = 1
   fpixel = 1

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -3,7 +3,7 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
   use Constants, only: pi, clight, parsec, AU
   use InOut
   IMPLICIT NONE
-  character(len=500),intent(in) :: filename
+  character(len=*),intent(in) :: filename
   integer, intent(in) :: nv, n
   double precision, intent(in) :: restlam, reflam
   logical, intent(in) :: specunitwl

--- a/writeFITS.f90
+++ b/writeFITS.f90
@@ -1,5 +1,5 @@
 subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
-  use GlobalSetup, only: Rout, distance, lmin, vresolution
+  use GlobalSetup, only: Rout, distance, lmin, vresolution, dlam_cube
   use Constants, only: pi, clight, parsec, AU
   use InOut
   IMPLICIT NONE
@@ -85,9 +85,10 @@ subroutine writefitsfile(filename, im, nv, n, restlam, reflam, specunitwl)
     call ftpkys(unit, 'CTYPE3', 'WAVE', '[micron]', status)
     call ftpkys(unit, 'cunit3', 'um      ', '', status)
     call ftpkyd(unit, 'crval3', reflam, 12, 'Reference wl', status)
-    call ftpkyd(unit, 'CDELT3', delwl, 12, 'd_wl (channel width)', status)
+    call ftpkyd(unit, 'CDELT3', dlam_cube, 12, 'd_wl (channel width)', status)
     call ftpkyd(unit, 'crpix3', 1.0, 12, 'Reference channel', status)
   else
+    ! FIXME: not really supported at the momement
     !----- spectral axis -----
     ! Frequency/Spectral coordinate
     ! the first channel (velo) point is the reference


### PR DESCRIPTION
Produce a fits line cube for the considered wavelength range and considered molecules (all in one). 

## Requirements

- [x]  fix what is already there and check it with a linecube produced for ProDiMo (single line). 
- [x] some input parameters might be missing (e.g. number of spatial pixels for the output ... maybe more)
- [x] proper "conversion" of Jy/area (from spectrum calculation) to Jy/pixel might be necessary
- [x] line cube might be huge, and needs a large fits file support (e.g. check what is required to produce something for JWST) 
- [x] apply a coordinate system to the cube (RA, Dex, e.g. like in ProDiMo, maybe make that optional)
- [x] units should be Jansky per pixel (e.g. okay for JWST and CASA/ALMA) 

## Optional 
- [ ] spectral axis might need to be flexible to e.g. produce something for CASA (velocity) and or JWST (micron) (optional as can also be done outside)
